### PR TITLE
[SCRS-8740] added service criteria Q5 and updated tests

### DIFF
--- a/app/controllers/EligibilityController.scala
+++ b/app/controllers/EligibilityController.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import javax.inject.Inject
+
+import cats.data.OptionT
+import common.enums.CacheKeys.IneligibilityReason
+import connectors.KeystoreConnector
+import forms.ServiceCriteriaFormFactory
+import models.YesOrNoQuestion
+import models.api.VatServiceEligibility
+import models.view.EligibilityQuestion
+import play.api.data.Form
+import play.api.i18n.MessagesApi
+import play.api.mvc.{Action, AnyContent}
+import services.{CurrentProfileService, S4LService, VatRegistrationService}
+import utils.SessionProfile
+
+import scala.concurrent.Future
+
+/**
+  * Created by eric on 29/09/17.
+  */
+class EligibilityController @Inject()(val keystoreConnector: KeystoreConnector,
+                                      val currentProfileService: CurrentProfileService,
+                                      implicit val messagesApi: MessagesApi,
+                                      implicit val vrs: VatRegistrationService,
+                                      implicit val s4l: S4LService)
+  extends VatRegistrationController with SessionProfile{
+
+  val criteriaName = "applyingForVatExemption"
+  def nextPage = controllers.routes.ServiceCriteriaQuestionsController.show("companyWillDoAnyOf")
+
+  def showExemptionCriteria : Action[AnyContent] = authorised.async{
+    implicit user =>
+      implicit request => withCurrentProfile{
+        implicit profile =>
+          val question = EligibilityQuestion(criteriaName)
+          val form: Form[YesOrNoQuestion] = ServiceCriteriaFormFactory.form(question.name)
+          viewModel[VatServiceEligibility]()
+            .flatMap(e => OptionT.fromOption(e.getAnswer(question)))
+            .fold(form)(answer => form.fill(YesOrNoQuestion(question.name, answer)))
+            .map(f => Ok(views.html.pages.applying_for_vat_exemption(f)))
+      }
+  }
+
+  def submitExemptionCriteria: Action[AnyContent] = authorised.async {
+    implicit  user =>
+      implicit request => withCurrentProfile{
+        implicit profile =>
+          import common.ConditionalFlatMap._
+          val question = EligibilityQuestion(criteriaName)
+          ServiceCriteriaFormFactory.form(criteriaName).bindFromRequest().fold(
+            hasErrors => Future.successful(BadRequest(views.html.pages.applying_for_vat_exemption(hasErrors))),
+            data => for {
+              vatEligibility  <- viewModel[VatServiceEligibility]().getOrElse(VatServiceEligibility())
+              _               <- save(vatEligibility.setAnswer(question, data.answer))
+              exit            = data.answer == question.exitAnswer
+              _               <- keystoreConnector.cache(IneligibilityReason.toString, question.name) onlyIf exit
+            } yield Redirect(if(exit) controllers.routes.ServiceCriteriaQuestionsController.ineligible() else nextPage)
+          )
+      }
+  }
+}

--- a/app/controllers/ServiceCriteriaQuestionsController.scala
+++ b/app/controllers/ServiceCriteriaQuestionsController.scala
@@ -45,8 +45,8 @@ class ServiceCriteriaQuestionsController @Inject()(val keystoreConnector: Keysto
     case HaveNinoQuestion            => controllers.routes.ServiceCriteriaQuestionsController.show(DoingBusinessAbroadQuestion.name)
     case DoingBusinessAbroadQuestion => controllers.routes.ServiceCriteriaQuestionsController.show(DoAnyApplyToYouQuestion.name)
     case DoAnyApplyToYouQuestion     => controllers.routes.ServiceCriteriaQuestionsController.show(ApplyingForAnyOfQuestion.name)
-    case ApplyingForAnyOfQuestion    => controllers.routes.ServiceCriteriaQuestionsController.show(CompanyWillDoAnyOfQuestion.name)
-    case CompanyWillDoAnyOfQuestion  => controllers.routes.EligibilitySuccessController.show
+    case ApplyingForAnyOfQuestion    => controllers.routes.EligibilityController.showExemptionCriteria()
+    case CompanyWillDoAnyOfQuestion  => controllers.routes.EligibilitySuccessController.show()
   }
 
   private def viewForQuestion(q: EligibilityQuestion, form: Form[YesOrNoQuestion])(implicit r: Request[AnyContent]) = q match {
@@ -89,6 +89,11 @@ class ServiceCriteriaQuestionsController @Inject()(val keystoreConnector: Keysto
 
   def ineligible(): Action[AnyContent] = authorised.async(implicit user => implicit request =>
     OptionT(keystoreConnector.fetchAndGet[String](IneligibilityReason.toString)).getOrElse("")
-      .map(failedQuestion => Ok(views.html.pages.ineligible(failedQuestion))))
+      .map{
+        failedQuestion => failedQuestion match {
+          case "applyingForVatExemption" => Ok(views.html.pages.exemption_ineligible())
+          case _ => Ok(views.html.pages.ineligible(failedQuestion))
+        }
+      })
 
 }

--- a/app/controllers/test/TestSetupController.scala
+++ b/app/controllers/test/TestSetupController.scala
@@ -52,6 +52,7 @@ class TestSetupController @Inject()(implicit s4LService: S4LService,
                 doingBusinessAbroad = eligibility.flatMap(_.vatEligibility).map(_.doingBusinessAbroad.getOrElse("").toString),
                 doAnyApplyToYou = eligibility.flatMap(_.vatEligibility).map(_.doAnyApplyToYou.getOrElse("").toString),
                 applyingForAnyOf = eligibility.flatMap(_.vatEligibility).map(_.applyingForAnyOf.getOrElse("").toString),
+                applyingForVatExemption = eligibility.flatMap(_.vatEligibility).map(_.applyingForVatExemption.getOrElse("").toString),
                 companyWillDoAnyOf = eligibility.flatMap(_.vatEligibility).map(_.companyWillDoAnyOf.getOrElse("").toString)
               ),
               VatEligibilityChoiceTestSetup(
@@ -86,6 +87,7 @@ class TestSetupController @Inject()(implicit s4LService: S4LService,
                            x.vatServiceEligibility.doingBusinessAbroad.map(_.toBoolean),
                            x.vatServiceEligibility.doAnyApplyToYou.map(_.toBoolean),
                            x.vatServiceEligibility.applyingForAnyOf.map(_.toBoolean),
+                           x.vatServiceEligibility.applyingForVatExemption.map(_.toBoolean),
                            x.vatServiceEligibility.companyWillDoAnyOf.map(_.toBoolean))))
                          })
                   _ <- s4LService.save(s4LBuilder.eligiblityChoiceFromData(data))

--- a/app/forms/test/TestSetupForm.scala
+++ b/app/forms/test/TestSetupForm.scala
@@ -36,6 +36,7 @@ object TestSetupForm {
     "doingBusinessAbroad" -> optional(text),
     "doAnyApplyToYou" -> optional(text),
     "applyingForAnyOf" -> optional(text),
+    "applyingForVatExemption" -> optional(text),
     "companyWillDoAnyOf" -> optional(text)
   )(VatServiceEligibilityTestSetup.apply)(VatServiceEligibilityTestSetup.unapply)
 

--- a/app/models/S4LModels.scala
+++ b/app/models/S4LModels.scala
@@ -56,6 +56,7 @@ object S4LVatEligibility {
         doingBusinessAbroad = ve.doingBusinessAbroad,
         doAnyApplyToYou = ve.doAnyApplyToYou,
         applyingForAnyOf = ve.applyingForAnyOf,
+        applyingForVatExemption = ve.applyingForVatExemption,
         companyWillDoAnyOf = ve.companyWillDoAnyOf,
         vatEligibilityChoice = ve.vatEligibilityChoice)
       ).getOrElse(error)

--- a/app/models/api/VatServiceEligibility.scala
+++ b/app/models/api/VatServiceEligibility.scala
@@ -26,6 +26,7 @@ case class VatServiceEligibility(haveNino: Option[Boolean] = None,
                                  doingBusinessAbroad: Option[Boolean] = None,
                                  doAnyApplyToYou: Option[Boolean] = None,
                                  applyingForAnyOf: Option[Boolean] = None,
+                                 applyingForVatExemption: Option[Boolean] = None,
                                  companyWillDoAnyOf: Option[Boolean] = None,
                                  vatEligibilityChoice: Option[VatEligibilityChoice] = None) {
 
@@ -34,6 +35,7 @@ case class VatServiceEligibility(haveNino: Option[Boolean] = None,
     case DoingBusinessAbroadQuestion => doingBusinessAbroad
     case DoAnyApplyToYouQuestion => doAnyApplyToYou
     case ApplyingForAnyOfQuestion => applyingForAnyOf
+    case ApplyingForVatExemptionQuestion => applyingForVatExemption
     case CompanyWillDoAnyOfQuestion => companyWillDoAnyOf
   }
 
@@ -42,6 +44,7 @@ case class VatServiceEligibility(haveNino: Option[Boolean] = None,
     case DoingBusinessAbroadQuestion => this.copy(doingBusinessAbroad = Some(answer))
     case DoAnyApplyToYouQuestion => this.copy(doAnyApplyToYou = Some(answer))
     case ApplyingForAnyOfQuestion => this.copy(applyingForAnyOf = Some(answer))
+    case ApplyingForVatExemptionQuestion => this.copy(applyingForVatExemption = Some(answer))
     case CompanyWillDoAnyOfQuestion => this.copy(companyWillDoAnyOf = Some(answer))
   }
 

--- a/app/models/test/TestSetup.scala
+++ b/app/models/test/TestSetup.scala
@@ -22,6 +22,7 @@ case class VatServiceEligibilityTestSetup(haveNino: Option[String],
                                           doingBusinessAbroad: Option[String],
                                           doAnyApplyToYou: Option[String],
                                           applyingForAnyOf: Option[String],
+                                          applyingForVatExemption: Option[String],
                                           companyWillDoAnyOf: Option[String])
 
 object VatServiceEligibilityTestSetup {

--- a/app/models/view/EligibilityQuestion.scala
+++ b/app/models/view/EligibilityQuestion.scala
@@ -28,12 +28,15 @@ object EligibilityQuestion {
 
   case object ApplyingForAnyOfQuestion extends EligibilityQuestion("applyingForAnyOf", exitAnswer = true)
 
+  case object ApplyingForVatExemptionQuestion extends EligibilityQuestion("applyingForVatExemption", exitAnswer = true)
+
   case object CompanyWillDoAnyOfQuestion extends EligibilityQuestion("companyWillDoAnyOf", exitAnswer = true)
 
   private val questions = Seq(HaveNinoQuestion,
     DoingBusinessAbroadQuestion,
     DoAnyApplyToYouQuestion,
     ApplyingForAnyOfQuestion,
+    ApplyingForVatExemptionQuestion,
     CompanyWillDoAnyOfQuestion)
 
   def apply(s: String): EligibilityQuestion = questions.find(_.name == s)

--- a/app/views/pages/applying_for_vat_exemption.scala.html
+++ b/app/views/pages/applying_for_vat_exemption.scala.html
@@ -1,0 +1,80 @@
+@*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import models.YesOrNoQuestion
+@(applyingForVatExemptionForm: Form[YesOrNoQuestion])(implicit request: Request[_], messages: Messages)
+@import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
+@import views.html.helpers.errorSummary
+
+@main_template(title = messages("pages.eligibility.applyingForVatExemption.title")) {
+
+<div class="column-two-thirds">
+
+    @errorSummary(
+    messages("app.common.errorSummaryLabel"),
+    applyingForVatExemptionForm
+    )
+
+    <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.eligibility.applyingForVatExemption.heading")</h1>
+
+    <p>@messages("pages.eligibility.applyingForVatExemption.p1")</p>
+    <p>@messages("pages.eligibility.applyingForVatExemption.p2")</p>
+
+
+    <div class="form-group">
+        <details role="group">
+            <summary role="button" aria-controls="details-content-1" aria-expanded="false"><span class="summary">@messages("pages.eligibility.applyingForVatExemption.panel.title")</span></summary>
+            <div class="panel panel-indent" id="details-content-1" aria-hidden="true">
+                <p>@messages("pages.eligibility.applyingForVatExemption.panel.p1")</p>
+                <p>@messages("pages.eligibility.applyingForVatExemption.panel.p2")</p>
+                <ul class="list list-bullet">
+                    <li>@messages("pages.eligibility.applyingForVatExemption.panel.bullet1")</li>
+                    <li>@messages("pages.eligibility.applyingForVatExemption.panel.bullet2")</li>
+                    <li>@messages("pages.eligibility.applyingForVatExemption.panel.bullet3")</li>
+                    <li>@messages("pages.eligibility.applyingForVatExemption.panel.bullet4")</li>
+                    <li>@messages("pages.eligibility.applyingForVatExemption.panel.bullet5")</li>
+                </ul>
+                <p>@Html(messages("pages.eligibility.applyingForVatExemption.panel.p3"))</p>
+            </div>
+        </details>
+    </div>
+
+    @govHelpers.form(action = controllers.routes.EligibilityController.submitExemptionCriteria) {
+    <div class="form-group">
+        <fieldset class="inline">
+            <span id="applyingForVatExemptionRadio"/>
+
+            @govHelpers.inputRadioGroup(
+            field = applyingForVatExemptionForm("applyingForVatExemptionRadio"),
+            Seq(
+            "true" -> messages("app.common.yes"),
+            "false" -> messages("app.common.no")
+            ),
+            '_labelAfter -> true,
+            '_labelClass -> "block-label"
+            )
+        </fieldset>
+    </div>
+
+    <div class="form-group">
+        <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+    </div>
+
+    }
+
+</div>
+
+}

--- a/app/views/pages/exemption_ineligible.scala.html
+++ b/app/views/pages/exemption_ineligible.scala.html
@@ -1,0 +1,34 @@
+@*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@()(implicit request: Request[_], messages: Messages)
+@import uk.gov.hmrc.play.views.html.helpers.form
+
+@main_template(title = messages("pages.serviceCriteriaFailure.title")) {
+<div class="grid-row">
+    <div class="column-two-thirds">
+        <header class="page-header">
+            <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.serviceCriteriaFailure.heading")</h1>
+        </header>
+
+        <div id="applying-for-vat-exemption-text">
+            <p>@Html(messages("pages.serviceCriteriaFailure.applyingForVatExemption.p1"))</p>
+            <p>@Html(messages("pages.serviceCriteriaFailure.applyingForVatExemption.p2"))</p>
+        </div>
+
+    </div>
+</div>
+}

--- a/app/views/pages/test/test_setup.scala.html
+++ b/app/views/pages/test/test_setup.scala.html
@@ -28,6 +28,7 @@
             <p>@govHelpers.input(testSetupForm("vatServiceEligibility.doingBusinessAbroad"), '_label -> "Doing business abroad (true or false)")</p>
             <p>@govHelpers.input(testSetupForm("vatServiceEligibility.doAnyApplyToYou"), '_label -> "Do any apply to you (true or false)")</p>
             <p>@govHelpers.input(testSetupForm("vatServiceEligibility.applyingForAnyOf"), '_label -> "Applying for any of (true or false)")</p>
+            <p>@govHelpers.input(testSetupForm("vatServiceEligibility.applyingForVatExemption"), '_label -> "Applying for Vat exemption (true or false)")</p>
             <p>@govHelpers.input(testSetupForm("vatServiceEligibility.companyWillDoAnyOf"), '_label -> "Company will do any of (true or false)")</p>
 
             <b>VAT ELIGIBILITY CHOICE</b>

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -28,6 +28,8 @@ GET         /involved-more-business-changing-status           controllers.Servic
 POST        /involved-more-business-changing-status           controllers.ServiceCriteriaQuestionsController.submit(question = "doAnyApplyToYou")
 GET         /agricultural-flat-rate                           controllers.ServiceCriteriaQuestionsController.show(question = "applyingForAnyOf")
 POST        /agricultural-flat-rate                           controllers.ServiceCriteriaQuestionsController.submit(question = "applyingForAnyOf")
+GET         /apply-exception-exemption                        controllers.EligibilityController.showExemptionCriteria
+POST        /apply-exception-exemption                        controllers.EligibilityController.submitExemptionCriteria
 GET         /apply-for-any                                    controllers.ServiceCriteriaQuestionsController.show(question = "companyWillDoAnyOf")
 POST        /apply-for-any                                    controllers.ServiceCriteriaQuestionsController.submit(question = "companyWillDoAnyOf")
 

--- a/conf/messages
+++ b/conf/messages
@@ -71,6 +71,9 @@ pages.serviceCriteriaFailure.applyingForAnyOf.bullet2    = the company is applyi
 pages.serviceCriteriaFailure.applyingForAnyOf.p1         = If the company is applying for the Agricultural Flat Rate Scheme, you need to <a href="https://www.gov.uk/government/publications/vat-agricultural-flat-rate-scheme-application-for-certification-vat98">register using form VAT98</a>.
 pages.serviceCriteriaFailure.applyingForAnyOf.p2         = If the company is applying for an exception from VAT registration, you need to <a href="https://www.gov.uk/government/publications/vat-application-for-registration-vat1">register using form VAT1</a>.
 
+pages.serviceCriteriaFailure.applyingForVatExemption.p1    = If the company is applying for a VAT registration exception, let us know online through the <a href="https://www.gov.uk/government/organisations/hm-revenue-customs/contact/vat-online-services-helpdesk">VAT online services helpdesk</a> or send a letter explaining your circumstances to <a href="https://www.gov.uk/government/organisations/hm-revenue-customs/contact/vat-enquiries">HMRC VAT Registration Services</a>.
+pages.serviceCriteriaFailure.applyingForVatExemption.p2    = If the company is applying for an exemption from VAT registration, <a href="https://online.hmrc.gov.uk/registration/newbusiness/introduction">register using form VAT1</a>.
+
 pages.serviceCriteriaFailure.companyWillDoAnyOf.p1         = You can''t register with this service if the company:
 pages.serviceCriteriaFailure.companyWillDoAnyOf.bullet1    = hires out boats or aircraft to clients
 pages.serviceCriteriaFailure.companyWillDoAnyOf.bullet2    = owns one or more racehorses
@@ -87,6 +90,7 @@ validation.eligibility.doingBusinessAbroad.missing          = Tell us if you''ll
 validation.eligibility.doAnyApplyToYou.missing              = Tell us if any of the following apply to you or your business
 validation.eligibility.applyingForAnyOf.missing             = Tell us if you''ll apply for any of the following
 validation.eligibility.companyWillDoAnyOf.missing           = Tell us if you''ll do any of the following
+validation.eligibility.applyingForVatExemption.missing      = Tell us if the company is applying for either a VAT registration exception or an exemption
 
 ## Have Nino
 pages.eligibility.haveNino.title                            = Do you have a National Insurance number?
@@ -116,6 +120,21 @@ pages.eligibility.applyingForAnyOf.title                    = Is the company app
 pages.eligibility.applyingForAnyOf.heading                  = Is the company applying for either the Agricultural Flat Rate Scheme or the Annual Accounting Scheme?
 pages.eligibility.applyingForAnyOf.p1                       = The Agricultural Flat Rate Scheme is an alternative to VAT registration for farmers.
 pages.eligibility.applyingForAnyOf.p2                       = The Annual Accounting Scheme allows you to submit 1 VAT return a year and make advance payments towards your next VAT bill.
+
+## Is the company applying for either a VAT registration Exception or Exemption?
+pages.eligibility.applyingForVatExemption.title             = Is the company applying for either a VAT registration exception or exemption?
+pages.eligibility.applyingForVatExemption.heading           = Is the company applying for either a VAT registration exception or exemption?
+pages.eligibility.applyingForVatExemption.p1                = The company can get a registration exception if VAT taxable sales temporarily went over the VAT threshold (currently £85000) but have since dropped below it.
+pages.eligibility.applyingForVatExemption.p2                = The company can get a registration exemption if it sells mainly or only zero-rated goods or services.
+pages.eligibility.applyingForVatExemption.panel.title       = Examples of zero-rated goods or services
+pages.eligibility.applyingForVatExemption.panel.p1          = Zero-rated goods and services are VAT-taxable but the VAT rate on them is 0%.
+pages.eligibility.applyingForVatExemption.panel.p2          = They include:
+pages.eligibility.applyingForVatExemption.panel.bullet1     = most food and drink (but not things like alcoholic drinks, confectionery, crisps and savoury snacks, hot food, sports drinks, hot takeaways, ice cream, soft drinks and mineral water)
+pages.eligibility.applyingForVatExemption.panel.bullet2     = books and newspapers
+pages.eligibility.applyingForVatExemption.panel.bullet3     = printing services for brochures, leaflets or pamphlets
+pages.eligibility.applyingForVatExemption.panel.bullet4     = children’s clothes and shoes
+pages.eligibility.applyingForVatExemption.panel.bullet5     = most goods you export to non-EU countries
+pages.eligibility.applyingForVatExemption.panel.p3          = Find out about <a href="https://www.gov.uk/guidance/rates-of-vat-on-different-goods-and-services">VAT rates on different goods and services</a>.
 
 pages.eligibility.companyWillDoAnyOf.title                   = Will the company do any of the following once it''s registered for VAT?
 pages.eligibility.companyWillDoAnyOf.heading                 = Will the company do any of the following once it''s registered for VAT?

--- a/it/controllers/ThresholdControllerISpec.scala
+++ b/it/controllers/ThresholdControllerISpec.scala
@@ -33,7 +33,7 @@ class ThresholdControllerISpec extends PlaySpec with AppAndStubs with ScalaFutur
       "user successfully submits a valid form" in {
         val optVatChoice = Some(VatEligibilityChoice(necessity = "obligatory"))
 
-        val eligibility = VatServiceEligibility(Some(true),Some(false),Some(false),Some(false),Some(false),optVatChoice)
+        val eligibility = VatServiceEligibility(Some(true),Some(false),Some(false),Some(false),Some(false),Some(false),optVatChoice)
 
         val s4lEligibility = Json.toJson(S4LVatEligibility(Some(eligibility)))
 
@@ -189,7 +189,7 @@ class ThresholdControllerISpec extends PlaySpec with AppAndStubs with ScalaFutur
       "when the request is valid" in {
         val optVatChoice = Some(VatEligibilityChoice(necessity = "obligatory"))
 
-        val eligibility = VatServiceEligibility(Some(true),Some(false),Some(false),Some(false),Some(false),optVatChoice)
+        val eligibility = VatServiceEligibility(Some(true),Some(false),Some(false),Some(false),Some(false),Some(false),optVatChoice)
 
         val s4lEligibility = Json.toJson(S4LVatEligibility(Some(eligibility)))
 

--- a/test/controllers/EligibilityControllerSpec.scala
+++ b/test/controllers/EligibilityControllerSpec.scala
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import common.enums.CacheKeys.IneligibilityReason
+import connectors.KeystoreConnector
+import fixtures.VatRegistrationFixture
+import helpers.{S4LMockSugar, VatRegSpec}
+import models.CurrentProfile
+import models.api.VatServiceEligibility
+import models.view.EligibilityQuestion
+import models.view.EligibilityQuestion.{ApplyingForVatExemptionQuestion, DoingBusinessAbroadQuestion, HaveNinoQuestion}
+import org.mockito.Matchers
+import org.mockito.Matchers.any
+import org.mockito.Mockito.when
+import play.api.mvc.{Request, Result}
+import play.api.test.FakeRequest
+import uk.gov.hmrc.http.cache.client.CacheMap
+import uk.gov.hmrc.play.frontend.auth.connectors.AuthConnector
+import uk.gov.hmrc.play.http.HeaderCarrier
+
+import scala.concurrent.Future
+
+class EligibilityControllerSpec extends VatRegSpec with VatRegistrationFixture with S4LMockSugar {
+
+  class Setup {
+    val testController = new EligibilityController(mockKeystoreConnector,
+      mockCurrentProfileService,
+      mockMessages,
+      mockVatRegistrationService,
+      mockS4LService) {
+      override val authConnector: AuthConnector = mockAuthConnector
+
+      override def withCurrentProfile(f: (CurrentProfile) => Future[Result])(implicit request: Request[_], hc: HeaderCarrier): Future[Result] = {
+        f(currentProfile)
+      }
+    }
+
+    def setupIneligibilityReason(keystoreConnector: KeystoreConnector, question: EligibilityQuestion) =
+      when(mockKeystoreConnector.fetchAndGet[String](Matchers.eq(IneligibilityReason.toString))(any(), any()))
+        .thenReturn(Some(question.name).pure)
+  }
+
+  "GET EligibilityController.showExemptionCriteria()" should {
+    "return HTML for relevant page with no data in the form" in new Setup {
+      save4laterReturnsViewModel[VatServiceEligibility](validServiceEligibility)()
+      val expectedTitle = "Is the company applying for either a VAT registration exception or exemption"
+      callAuthorised(testController.showExemptionCriteria())(_ includesText expectedTitle)
+    }
+  }
+
+  "POST ServiceCriteriaQuestionsController.submit()" should {
+
+    "redirect to company will do any of answer is yes" in new Setup {
+      when(mockVatRegistrationService.submitVatEligibility()(any(), any())).thenReturn(validServiceEligibility.pure)
+      val currentQuestion = ApplyingForVatExemptionQuestion
+
+      setupIneligibilityReason(mockKeystoreConnector, currentQuestion)
+      save4laterReturnsViewModel(validServiceEligibility)()
+      save4laterExpectsSave[VatServiceEligibility]()
+
+      submitAuthorised(testController.submitExemptionCriteria,
+        FakeRequest().withFormUrlEncodedBody(
+          "question" -> currentQuestion.name,
+          s"${currentQuestion.name}Radio" -> (!currentQuestion.exitAnswer).toString)
+      )(_ redirectsTo "/check-if-you-can-register-for-vat/apply-for-any")
+    }
+
+    "redirect to company will do any of answer is yes if s4l and backend is empty" in new Setup {
+      when(mockVatRegistrationService.submitVatEligibility()(any(), any())).thenReturn(validServiceEligibility.pure)
+      val currentQuestion = ApplyingForVatExemptionQuestion
+
+      setupIneligibilityReason(mockKeystoreConnector, currentQuestion)
+      save4laterReturnsNoViewModel[VatServiceEligibility]()
+      when(mockVatRegistrationService.getVatScheme()(any(),any())).thenReturn(validVatScheme.copy(vatServiceEligibility = None).pure)
+      save4laterExpectsSave[VatServiceEligibility]()
+
+      submitAuthorised(testController.submitExemptionCriteria,
+        FakeRequest().withFormUrlEncodedBody(
+          "question" -> currentQuestion.name,
+          s"${currentQuestion.name}Radio" -> (!currentQuestion.exitAnswer).toString)
+      )(_ redirectsTo "/check-if-you-can-register-for-vat/apply-for-any")
+    }
+
+    "400 for malformed requests" in new Setup {
+      val currentQuestion = ApplyingForVatExemptionQuestion
+
+      submitAuthorised(testController.submitExemptionCriteria,
+        FakeRequest().withFormUrlEncodedBody(s"${currentQuestion.name}Radio" -> "foo")
+      )(_ isA 400)
+    }
+
+    "show ineligible screen on no submitted" in new Setup {
+      val currentQuestion = ApplyingForVatExemptionQuestion
+
+      when(mockVatRegistrationService.submitVatEligibility()(any(), any())).thenReturn(validServiceEligibility.pure)
+      setupIneligibilityReason(mockKeystoreConnector, currentQuestion)
+      save4laterReturnsViewModel(validServiceEligibility)()
+      save4laterExpectsSave[VatServiceEligibility]()
+      when(mockKeystoreConnector.cache[String](any(), any())(any(), any())).thenReturn(CacheMap("id", Map()).pure)
+
+      submitAuthorised(testController.submitExemptionCriteria,
+        FakeRequest().withFormUrlEncodedBody(s"${currentQuestion.name}Radio" -> (currentQuestion.exitAnswer).toString)
+      )(_ redirectsTo "/check-if-you-can-register-for-vat/cant-register")
+    }
+
+
+  }
+
+}

--- a/test/fixtures/VatRegistrationFixture.scala
+++ b/test/fixtures/VatRegistrationFixture.scala
@@ -31,8 +31,8 @@ trait VatRegistrationFixture extends TradingDetailsFixture {
   val validHttpResponse = HttpResponse(OK)
 
   //Api models
-  val validServiceEligibility          = VatServiceEligibility(Some(true), Some(false), Some(false), Some(false), Some(false), Some(validVatChoice))
-  val validServiceEligibilityNoChoice  = VatServiceEligibility(Some(true), Some(false), Some(false), Some(false), Some(false))
+  val validServiceEligibility          = VatServiceEligibility(Some(true), Some(false), Some(false), Some(false), Some(false), Some(false), Some(validVatChoice))
+  val validServiceEligibilityNoChoice  = VatServiceEligibility(Some(true), Some(false), Some(false), Some(false), Some(false), Some(false))
   val validVatThresholdPostIncorp      = VatThresholdPostIncorp(overThresholdSelection = false, None)
 
   val emptyVatScheme = VatScheme(testRegId)


### PR DESCRIPTION
VRFE pr: https://github.com/hmrc/vat-registration-frontend/pull/283
VR pr: https://github.com/hmrc/vat-registration/pull/83
AT pr: /vat-registration-acceptance-tests/pull/124
PT pr: /HMRC/vat-registration-performance-tests/pull/28

Changed VRFE to point to VREFE by default feature switch now feature-flag/disableEligibilityFrontend/true