### PR TITLE
Refactor pages remove unnecessary .grid-row and .column-(size) divs

### DIFF
--- a/app/views/pages/applying_for_any_of.scala.html
+++ b/app/views/pages/applying_for_any_of.scala.html
@@ -22,41 +22,36 @@
 
 @main_template(title = messages("pages.eligibility.applyingForAnyOf.title")) {
 
-    <div class="column-two-thirds">
+    @errorSummary(
+        messages("app.common.errorSummaryLabel"),
+        applyingForAnyOfForm
+    )
 
-        @errorSummary(
-            messages("app.common.errorSummaryLabel"),
-            applyingForAnyOfForm
-        )
+    <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.eligibility.applyingForAnyOf.heading")</h1>
 
-        <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.eligibility.applyingForAnyOf.heading")</h1>
+    <p>@messages("pages.eligibility.applyingForAnyOf.p1")</p>
+    <p>@messages("pages.eligibility.applyingForAnyOf.p2")</p>
 
-        <p>@messages("pages.eligibility.applyingForAnyOf.p1")</p>
-        <p>@messages("pages.eligibility.applyingForAnyOf.p2")</p>
+    @govHelpers.form(action = controllers.routes.ServiceCriteriaQuestionsController.submit("applyingForAnyOf")) {
+        <div class="form-group">
+            <fieldset class="inline">
+                <span id="applyingForAnyOfRadio"/>
 
-        @govHelpers.form(action = controllers.routes.ServiceCriteriaQuestionsController.submit("applyingForAnyOf")) {
-            <div class="form-group">
-                <fieldset class="inline">
-                    <span id="applyingForAnyOfRadio"/>
+                @vatInputRadioGroup(
+                    field = applyingForAnyOfForm("applyingForAnyOfRadio"),
+                    Seq(
+                        "true" -> messages("app.common.yes"),
+                        "false" -> messages("app.common.no")
+                    ),
+                    '_labelAfter -> true,
+                    '_labelClass -> "block-label"
+                )
+            </fieldset>
+        </div>
 
-                    @vatInputRadioGroup(
-                        field = applyingForAnyOfForm("applyingForAnyOfRadio"),
-                        Seq(
-                            "true" -> messages("app.common.yes"),
-                            "false" -> messages("app.common.no")
-                        ),
-                        '_labelAfter -> true,
-                        '_labelClass -> "block-label"
-                    )
-                </fieldset>
-            </div>
+        <div class="form-group">
+            <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+        </div>
 
-            <div class="form-group">
-                <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-            </div>
-
-        }
-
-    </div>
-
+    }
 }

--- a/app/views/pages/applying_for_vat_exemption.scala.html
+++ b/app/views/pages/applying_for_vat_exemption.scala.html
@@ -22,8 +22,6 @@
 
 @main_template(title = messages("pages.eligibility.applyingForVatExemption.title")) {
 
-<div class="column-two-thirds">
-
     @errorSummary(
     messages("app.common.errorSummaryLabel"),
     applyingForVatExemptionForm
@@ -75,7 +73,4 @@
     </div>
 
     }
-
-</div>
-
 }

--- a/app/views/pages/company_will_do_any_of.scala.html
+++ b/app/views/pages/company_will_do_any_of.scala.html
@@ -22,50 +22,45 @@
 
 @main_template(title = messages("pages.eligibility.companyWillDoAnyOf.title")) {
 
-    <div class="column-two-thirds">
+    @errorSummary(
+        messages("app.common.errorSummaryLabel"),
+        companyWillDoAnyOfForm
+    )
 
-        @errorSummary(
-            messages("app.common.errorSummaryLabel"),
-            companyWillDoAnyOfForm
-        )
+    <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.eligibility.companyWillDoAnyOf.heading")</h1>
 
-        <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.eligibility.companyWillDoAnyOf.heading")</h1>
+    <p>@messages("pages.eligibility.companyWillDoAnyOf.p1")</p>
 
-        <p>@messages("pages.eligibility.companyWillDoAnyOf.p1")</p>
-
-        <div class="form-group">
-            <ul class="list list-bullet">
-                <li>@Html(messages("pages.eligibility.companyWillDoAnyOf.bullet1"))</li>
-                <li>@Html(messages("pages.eligibility.companyWillDoAnyOf.bullet2"))</li>
-                <li>@Html(messages("pages.eligibility.companyWillDoAnyOf.bullet3"))</li>
-            </ul>
-        </div>
-
-        @govHelpers.form(action = controllers.routes.ServiceCriteriaQuestionsController.submit("companyWillDoAnyOf")) {
-            <div class="form-group">
-                <fieldset class="inline">
-                    <span id="companyWillDoAnyOfRadio"/>
-
-                    @vatInputRadioGroup(
-                        field = companyWillDoAnyOfForm("companyWillDoAnyOfRadio"),
-                        Seq(
-                            "true" -> messages("app.common.yes"),
-                            "false" -> messages("app.common.no")
-                        ),
-                        '_labelAfter -> true,
-                        '_labelClass -> "block-label"
-                    )
-                </fieldset>
-            </div>
-
-
-
-            <div class="form-group">
-                <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-            </div>
-
-        }
-
+    <div class="form-group">
+        <ul class="list list-bullet">
+            <li>@Html(messages("pages.eligibility.companyWillDoAnyOf.bullet1"))</li>
+            <li>@Html(messages("pages.eligibility.companyWillDoAnyOf.bullet2"))</li>
+            <li>@Html(messages("pages.eligibility.companyWillDoAnyOf.bullet3"))</li>
+        </ul>
     </div>
 
+    @govHelpers.form(action = controllers.routes.ServiceCriteriaQuestionsController.submit("companyWillDoAnyOf")) {
+        <div class="form-group">
+            <fieldset class="inline">
+                <span id="companyWillDoAnyOfRadio"/>
+
+                @vatInputRadioGroup(
+                    field = companyWillDoAnyOfForm("companyWillDoAnyOfRadio"),
+                    Seq(
+                        "true" -> messages("app.common.yes"),
+                        "false" -> messages("app.common.no")
+                    ),
+                    '_labelAfter -> true,
+                    '_labelClass -> "block-label"
+                )
+            </fieldset>
+        </div>
+
+
+
+        <div class="form-group">
+            <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+        </div>
+
+    }
 }

--- a/app/views/pages/do_any_apply_to_you.scala.html
+++ b/app/views/pages/do_any_apply_to_you.scala.html
@@ -22,49 +22,44 @@
 
 @main_template(title = messages("pages.eligibility.doAnyApplyToYou.title")) {
 
-    <div class="column-two-thirds">
+    @errorSummary(
+        messages("app.common.errorSummaryLabel"),
+        doAnyApplyToYouForm
+    )
 
-        @errorSummary(
-            messages("app.common.errorSummaryLabel"),
-            doAnyApplyToYouForm
-        )
+    <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.eligibility.doAnyApplyToYou.heading")</h1>
 
-        <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.eligibility.doAnyApplyToYou.heading")</h1>
+    <p>@messages("pages.eligibility.doAnyApplyToYou.p1")</p>
 
-        <p>@messages("pages.eligibility.doAnyApplyToYou.p1")</p>
-
-        <div class="form-group">
-            <ul class="list list-bullet">
-                <li>@Html(messages("pages.eligibility.doAnyApplyToYou.bullet1"))</li>
-                <li>@Html(messages("pages.eligibility.doAnyApplyToYou.bullet2"))</li>
-                <li>@Html(messages("pages.eligibility.doAnyApplyToYou.bullet3"))</li>
-                <li>@Html(messages("pages.eligibility.doAnyApplyToYou.bullet4"))</li>
-            </ul>
-        </div>
-
-        @govHelpers.form(action = controllers.routes.ServiceCriteriaQuestionsController.submit("doAnyApplyToYou")) {
-            <div class="form-group">
-                <fieldset class="inline">
-                    <span id="doAnyApplyToYouRadio"/>
-
-                    @vatInputRadioGroup(
-                        field = doAnyApplyToYouForm("doAnyApplyToYouRadio"),
-                        Seq(
-                            "true" -> messages("app.common.yes"),
-                            "false" -> messages("app.common.no")
-                        ),
-                        '_labelAfter -> true,
-                        '_labelClass -> "block-label"
-                    )
-                </fieldset>
-            </div>
-
-            <div class="form-group">
-                <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-            </div>
-
-        }
-
+    <div class="form-group">
+        <ul class="list list-bullet">
+            <li>@Html(messages("pages.eligibility.doAnyApplyToYou.bullet1"))</li>
+            <li>@Html(messages("pages.eligibility.doAnyApplyToYou.bullet2"))</li>
+            <li>@Html(messages("pages.eligibility.doAnyApplyToYou.bullet3"))</li>
+            <li>@Html(messages("pages.eligibility.doAnyApplyToYou.bullet4"))</li>
+        </ul>
     </div>
 
+    @govHelpers.form(action = controllers.routes.ServiceCriteriaQuestionsController.submit("doAnyApplyToYou")) {
+        <div class="form-group">
+            <fieldset class="inline">
+                <span id="doAnyApplyToYouRadio"/>
+
+                @vatInputRadioGroup(
+                    field = doAnyApplyToYouForm("doAnyApplyToYouRadio"),
+                    Seq(
+                        "true" -> messages("app.common.yes"),
+                        "false" -> messages("app.common.no")
+                    ),
+                    '_labelAfter -> true,
+                    '_labelClass -> "block-label"
+                )
+            </fieldset>
+        </div>
+
+        <div class="form-group">
+            <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+        </div>
+
+    }
 }

--- a/app/views/pages/doing_business_abroad.scala.html
+++ b/app/views/pages/doing_business_abroad.scala.html
@@ -22,51 +22,46 @@
 
 @main_template(title = messages("pages.eligibility.doingBusinessAbroad.title")) {
 
-    <div class="column-one-third">
+    @errorSummary(
+        messages("app.common.errorSummaryLabel"),
+        doingBusinessAbroadForm
+    )
 
-        @errorSummary(
-            messages("app.common.errorSummaryLabel"),
-            doingBusinessAbroadForm
-        )
+    <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.eligibility.doingBusinessAbroad.heading")</h1>
 
-        <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.eligibility.doingBusinessAbroad.heading")</h1>
+    <p>@messages("pages.eligibility.doingBusinessAbroad.p1")</p>
 
-        <p>@messages("pages.eligibility.doingBusinessAbroad.p1")</p>
-
-        <div class="form-group">
-            <ul class="list list-bullet">
-                <li>@Html(messages("pages.eligibility.doingBusinessAbroad.bullet1"))</li>
-                <li>@messages("pages.eligibility.doingBusinessAbroad.bullet2")</li>
-                <li>@messages("pages.eligibility.doingBusinessAbroad.bullet3")</li>
-                <li>@messages("pages.eligibility.doingBusinessAbroad.bullet4")</li>
-                <li>@messages("pages.eligibility.doingBusinessAbroad.bullet5")</li>
-            </ul>
-        </div>
-
-        @govHelpers.form(action = controllers.routes.ServiceCriteriaQuestionsController.submit("doingBusinessAbroad")) {
-            <div class="form-group">
-                <fieldset class="inline">
-                    <span id="doingBusinessAbroadRadio"/>
-
-                    @vatInputRadioGroup(
-                        field = doingBusinessAbroadForm("doingBusinessAbroadRadio"),
-                        Seq(
-                            "true" -> messages("app.common.yes"),
-                            "false" -> messages("app.common.no")
-                        ),
-                        '_labelAfter -> true,
-                        '_labelClass -> "block-label"
-                    )
-                </fieldset>
-            </div>
-
-
-            <div class="form-group">
-                <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-            </div>
-
-        }
-
+    <div class="form-group">
+        <ul class="list list-bullet">
+            <li>@Html(messages("pages.eligibility.doingBusinessAbroad.bullet1"))</li>
+            <li>@messages("pages.eligibility.doingBusinessAbroad.bullet2")</li>
+            <li>@messages("pages.eligibility.doingBusinessAbroad.bullet3")</li>
+            <li>@messages("pages.eligibility.doingBusinessAbroad.bullet4")</li>
+            <li>@messages("pages.eligibility.doingBusinessAbroad.bullet5")</li>
+        </ul>
     </div>
 
+    @govHelpers.form(action = controllers.routes.ServiceCriteriaQuestionsController.submit("doingBusinessAbroad")) {
+        <div class="form-group">
+            <fieldset class="inline">
+                <span id="doingBusinessAbroadRadio"/>
+
+                @vatInputRadioGroup(
+                    field = doingBusinessAbroadForm("doingBusinessAbroadRadio"),
+                    Seq(
+                        "true" -> messages("app.common.yes"),
+                        "false" -> messages("app.common.no")
+                    ),
+                    '_labelAfter -> true,
+                    '_labelClass -> "block-label"
+                )
+            </fieldset>
+        </div>
+
+
+        <div class="form-group">
+            <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+        </div>
+
+    }
 }

--- a/app/views/pages/eligible.scala.html
+++ b/app/views/pages/eligible.scala.html
@@ -19,61 +19,55 @@
 
 @main_template(title = messages("pages.serviceCriteriaSuccess.title")) {
 
-<div class="grid-row">
-    <div class="column-one-third">
+    <header class="page-header">
+        <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.serviceCriteriaSuccess.heading")</h1>
+    </header>
 
-        <header class="page-header">
-            <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.serviceCriteriaSuccess.heading")</h1>
-        </header>
+    <p>@messages("pages.serviceCriteriaSuccess.para1")</p>
 
-        <p>@messages("pages.serviceCriteriaSuccess.para1")</p>
-
-        <div class="form-group">
-            <ul class="list list-bullet">
-                <li>@messages("pages.serviceCriteriaSuccess.bullet.details.bullet1")</li>
-                <li>@messages("pages.serviceCriteriaSuccess.bullet.details.bullet2")</li>
-            </ul>
-        </div>
-
-        <p>@messages("pages.serviceCriteriaSuccess.note.registrationTime")</p>
-
-        <div class="form-group">
-
-            <details role="group">
-                <summary role="button" aria-controls="details-content-1" aria-expanded="false"><span class="summary">@messages("pages.serviceCriteriaSuccess.panels.vatVoluntarily.title")</span></summary>
-                <div class="panel panel-indent" id="details-content-1" aria-hidden="true">
-                    <p>@messages("pages.serviceCriteriaSuccess.panels.vatVoluntarily.para1")</p>
-                    <p>@messages("pages.serviceCriteriaSuccess.panels.vatVoluntarily.para2")</p>
-                    <ul class="list list-bullet">
-                        <li>@Html(messages("pages.serviceCriteriaSuccess.panels.vatVoluntarily.bullet.charge"))</li>
-                        <li>@Html(messages("pages.serviceCriteriaSuccess.panels.vatVoluntarily.bullet.reclaim"))</li>
-                        <li>@messages("pages.serviceCriteriaSuccess.panels.vatVoluntarily.bullet.invoices")</li>
-                    </ul>
-                    <p>@messages("pages.serviceCriteriaSuccess.panels.vatVoluntarily.para3")</p>
-                    <p>@messages("pages.serviceCriteriaSuccess.panels.vatVoluntarily.para4")</p>
-                </div>
-            </details>
-
-            <details role="group">
-                <summary role="button" aria-controls="details-content-2" aria-expanded="false"><span class="summary">@messages("pages.serviceCriteriaSuccess.panels.vatResponsibilities.title")</span></summary>
-                <div class="panel panel-indent" id="details-content-2" aria-hidden="true">
-                    <p>@messages("pages.serviceCriteriaSuccess.panels.vatResponsibilities.para1")</p>
-                    <ul class="list list-bullet">
-                        <li>@Html(messages("pages.serviceCriteriaSuccess.panels.vatResponsibilities.bullet.charge"))</li>
-                        <li>@messages("pages.serviceCriteriaSuccess.panels.vatResponsibilities.bullet.pay")</li>
-                        <li>@messages("pages.serviceCriteriaSuccess.panels.vatResponsibilities.bullet.submit")</li>
-                        <li>@messages("pages.serviceCriteriaSuccess.panels.vatResponsibilities.bullet.records")</li>
-                    </ul>
-                </div>
-            </details>
-        </div>
-
-        @form(action = controllers.routes.EligibilitySuccessController.submit()) {
-            <div class="form-group">
-                <button class="button-get-started" role="button" id="save-and-continue">@messages("app.common.continue")</button>
-            </div>
-        }
+    <div class="form-group">
+        <ul class="list list-bullet">
+            <li>@messages("pages.serviceCriteriaSuccess.bullet.details.bullet1")</li>
+            <li>@messages("pages.serviceCriteriaSuccess.bullet.details.bullet2")</li>
+        </ul>
     </div>
 
-</div>
+    <p>@messages("pages.serviceCriteriaSuccess.note.registrationTime")</p>
+
+    <div class="form-group">
+
+        <details role="group">
+            <summary role="button" aria-controls="details-content-1" aria-expanded="false"><span class="summary">@messages("pages.serviceCriteriaSuccess.panels.vatVoluntarily.title")</span></summary>
+            <div class="panel panel-indent" id="details-content-1" aria-hidden="true">
+                <p>@messages("pages.serviceCriteriaSuccess.panels.vatVoluntarily.para1")</p>
+                <p>@messages("pages.serviceCriteriaSuccess.panels.vatVoluntarily.para2")</p>
+                <ul class="list list-bullet">
+                    <li>@Html(messages("pages.serviceCriteriaSuccess.panels.vatVoluntarily.bullet.charge"))</li>
+                    <li>@Html(messages("pages.serviceCriteriaSuccess.panels.vatVoluntarily.bullet.reclaim"))</li>
+                    <li>@messages("pages.serviceCriteriaSuccess.panels.vatVoluntarily.bullet.invoices")</li>
+                </ul>
+                <p>@messages("pages.serviceCriteriaSuccess.panels.vatVoluntarily.para3")</p>
+                <p>@messages("pages.serviceCriteriaSuccess.panels.vatVoluntarily.para4")</p>
+            </div>
+        </details>
+
+        <details role="group">
+            <summary role="button" aria-controls="details-content-2" aria-expanded="false"><span class="summary">@messages("pages.serviceCriteriaSuccess.panels.vatResponsibilities.title")</span></summary>
+            <div class="panel panel-indent" id="details-content-2" aria-hidden="true">
+                <p>@messages("pages.serviceCriteriaSuccess.panels.vatResponsibilities.para1")</p>
+                <ul class="list list-bullet">
+                    <li>@Html(messages("pages.serviceCriteriaSuccess.panels.vatResponsibilities.bullet.charge"))</li>
+                    <li>@messages("pages.serviceCriteriaSuccess.panels.vatResponsibilities.bullet.pay")</li>
+                    <li>@messages("pages.serviceCriteriaSuccess.panels.vatResponsibilities.bullet.submit")</li>
+                    <li>@messages("pages.serviceCriteriaSuccess.panels.vatResponsibilities.bullet.records")</li>
+                </ul>
+            </div>
+        </details>
+    </div>
+
+    @form(action = controllers.routes.EligibilitySuccessController.submit()) {
+        <div class="form-group">
+            <button class="button-get-started" role="button" id="save-and-continue">@messages("app.common.continue")</button>
+        </div>
+    }
 }

--- a/app/views/pages/exemption_ineligible.scala.html
+++ b/app/views/pages/exemption_ineligible.scala.html
@@ -18,17 +18,12 @@
 @import uk.gov.hmrc.play.views.html.helpers.form
 
 @main_template(title = messages("pages.serviceCriteriaFailure.title")) {
-<div class="grid-row">
-    <div class="column-two-thirds">
-        <header class="page-header">
-            <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.serviceCriteriaFailure.heading")</h1>
-        </header>
+  <header class="page-header">
+      <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.serviceCriteriaFailure.heading")</h1>
+  </header>
 
-        <div id="applying-for-vat-exemption-text">
-            <p>@Html(messages("pages.serviceCriteriaFailure.applyingForVatExemption.p1"))</p>
-            <p>@Html(messages("pages.serviceCriteriaFailure.applyingForVatExemption.p2"))</p>
-        </div>
-
-    </div>
-</div>
+  <div id="applying-for-vat-exemption-text">
+      <p>@Html(messages("pages.serviceCriteriaFailure.applyingForVatExemption.p1"))</p>
+      <p>@Html(messages("pages.serviceCriteriaFailure.applyingForVatExemption.p2"))</p>
+  </div>
 }

--- a/app/views/pages/have_nino.scala.html
+++ b/app/views/pages/have_nino.scala.html
@@ -22,38 +22,33 @@
 
 @main_template(title = messages("pages.eligibility.haveNino.title")) {
 
-    <div class="column-one-third">
+    @errorSummary(
+        messages("app.common.errorSummaryLabel"),
+        haveNinoForm
+    )
 
-        @errorSummary(
-            messages("app.common.errorSummaryLabel"),
-            haveNinoForm
-        )
+    <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.eligibility.haveNino.heading")</h1>
 
-        <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.eligibility.haveNino.heading")</h1>
+    @govHelpers.form(action = controllers.routes.ServiceCriteriaQuestionsController.submit("haveNino")) {
+        <div class="form-group">
+            <fieldset class="inline">
+                <span id="haveNinoRadio"/>
 
-        @govHelpers.form(action = controllers.routes.ServiceCriteriaQuestionsController.submit("haveNino")) {
-            <div class="form-group">
-                <fieldset class="inline">
-                    <span id="haveNinoRadio"/>
+                @vatInputRadioGroup(
+                    field = haveNinoForm("haveNinoRadio"),
+                    Seq(
+                        "true" -> messages("app.common.yes"),
+                        "false" -> messages("app.common.no")
+                    ),
+                    '_labelAfter -> true,
+                    '_labelClass -> "block-label"
+                )
+            </fieldset>
+        </div>
 
-                    @vatInputRadioGroup(
-                        field = haveNinoForm("haveNinoRadio"),
-                        Seq(
-                            "true" -> messages("app.common.yes"),
-                            "false" -> messages("app.common.no")
-                        ),
-                        '_labelAfter -> true,
-                        '_labelClass -> "block-label"
-                    )
-                </fieldset>
-            </div>
+        <div class="form-group">
+            <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+        </div>
 
-            <div class="form-group">
-                <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-            </div>
-
-        }
-
-    </div>
-
+    }
 }

--- a/app/views/pages/ineligible.scala.html
+++ b/app/views/pages/ineligible.scala.html
@@ -19,94 +19,87 @@
 
 @main_template(title = messages("pages.serviceCriteriaFailure.title")) {
 
-    <div class="grid-row">
-        <div class="column-two-thirds">
+    <header class="page-header">
+        <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.serviceCriteriaFailure.heading")</h1>
+    </header>
 
-            <header class="page-header">
-                <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.serviceCriteriaFailure.heading")</h1>
-            </header>
+    @defining((in:String) => if (in == thisSection) "" else "hidden") { cssClass =>
 
-            @defining((in:String) => if (in == thisSection) "" else "hidden") { cssClass =>
+        <div id="nino-text" class="@cssClass("haveNino")">
 
-                <div id="nino-text" class="@cssClass("haveNino")">
+            <p>@messages("pages.serviceCriteriaFailure.nino.p1")</p>
 
-                    <p>@messages("pages.serviceCriteriaFailure.nino.p1")</p>
-
-                    <p>@Html(messages("pages.serviceCriteriaFailure.linkToLegacyApp"))</p>
-
-                </div>
-
-                <div id="business-abroad-text" class="@cssClass("doingBusinessAbroad")">
-
-                    <p>@Html(messages("pages.serviceCriteriaFailure.linkToLegacyApp2"))</p>
-
-                    <ul class="list list-bullet">
-                        <li>@Html(messages("pages.serviceCriteriaFailure.businessAbroad.bullet1"))</li>
-                        <li>@Html(messages("pages.serviceCriteriaFailure.businessAbroad.bullet2"))</li>
-                    </ul>
-
-                    <p>@Html(messages("pages.serviceCriteriaFailure.businessAbroad.p1"))</p>
-                    <p>@Html(messages("pages.serviceCriteriaFailure.businessAbroad.p2"))</p>
-                    <p>@Html(messages("pages.serviceCriteriaFailure.businessAbroad.p3"))</p>
-
-                </div>
-
-                <div id="do-any-apply-to-you-text" class="@cssClass("doAnyApplyToYou")">
-
-                    <p>@Html(messages("pages.serviceCriteriaFailure.linkToLegacyApp2"))</p>
-
-                    <ul class="list list-bullet">
-                        <li>@Html(messages("pages.serviceCriteriaFailure.doAnyApplyToYou.bullet1"))</li>
-                        <li>@Html(messages("pages.serviceCriteriaFailure.doAnyApplyToYou.bullet2"))</li>
-                        <li>@Html(messages("pages.serviceCriteriaFailure.doAnyApplyToYou.bullet3"))</li>
-                        <li>@Html(messages("pages.serviceCriteriaFailure.doAnyApplyToYou.bullet4"))</li>
-                    </ul>
-
-                    <p>@Html(messages("pages.serviceCriteriaFailure.doAnyApplyToYou.p1"))</p>
-
-                </div>
-
-                <div id="applying-for-any-of-text" class="@cssClass("applyingForAnyOf")">
-
-                    <p>@Html(messages("pages.serviceCriteriaFailure.linkToLegacyApp2"))</p>
-
-                    <ul class="list list-bullet">
-                        <li>@Html(messages("pages.serviceCriteriaFailure.applyingForAnyOf.bullet1"))</li>
-                        <li>@Html(messages("pages.serviceCriteriaFailure.applyingForAnyOf.bullet2"))</li>
-                    </ul>
-
-                    <p>@Html(messages("pages.serviceCriteriaFailure.applyingForAnyOf.p1"))</p>
-                    <p>@Html(messages("pages.serviceCriteriaFailure.applyingForAnyOf.p2"))</p>
-
-                </div>
-
-                <div id="company-will-do-any-of-text" class="@cssClass("companyWillDoAnyOf")">
-
-                    <p>@Html(messages("pages.serviceCriteriaFailure.companyWillDoAnyOf.p1"))</p>
-
-                    <ul class="list list-bullet">
-                        <li>@Html(messages("pages.serviceCriteriaFailure.companyWillDoAnyOf.bullet1"))</li>
-                        <li>@Html(messages("pages.serviceCriteriaFailure.companyWillDoAnyOf.bullet2"))</li>
-                        <li>@Html(messages("pages.serviceCriteriaFailure.companyWillDoAnyOf.bullet3"))</li>
-                    </ul>
-
-                    <p>@Html(messages("pages.serviceCriteriaFailure.linkToLegacyApp"))</p>
-
-                </div>
-
-
-                <p>&nbsp;</p>
-            }
-
-            @form(action = Call("GET", "https://online.hmrc.gov.uk/registration/newbusiness/business-allowed")) {
-                <div class="form-group">
-                    <button type="submit" class="btn button" role="button" id="continue">
-                    @messages("pages.serviceCriteriaFailure.button.linkToLegacyApp")
-                    </button>
-                </div>
-            }
+            <p>@Html(messages("pages.serviceCriteriaFailure.linkToLegacyApp"))</p>
 
         </div>
 
-    </div>
+        <div id="business-abroad-text" class="@cssClass("doingBusinessAbroad")">
+
+            <p>@Html(messages("pages.serviceCriteriaFailure.linkToLegacyApp2"))</p>
+
+            <ul class="list list-bullet">
+                <li>@Html(messages("pages.serviceCriteriaFailure.businessAbroad.bullet1"))</li>
+                <li>@Html(messages("pages.serviceCriteriaFailure.businessAbroad.bullet2"))</li>
+            </ul>
+
+            <p>@Html(messages("pages.serviceCriteriaFailure.businessAbroad.p1"))</p>
+            <p>@Html(messages("pages.serviceCriteriaFailure.businessAbroad.p2"))</p>
+            <p>@Html(messages("pages.serviceCriteriaFailure.businessAbroad.p3"))</p>
+
+        </div>
+
+        <div id="do-any-apply-to-you-text" class="@cssClass("doAnyApplyToYou")">
+
+            <p>@Html(messages("pages.serviceCriteriaFailure.linkToLegacyApp2"))</p>
+
+            <ul class="list list-bullet">
+                <li>@Html(messages("pages.serviceCriteriaFailure.doAnyApplyToYou.bullet1"))</li>
+                <li>@Html(messages("pages.serviceCriteriaFailure.doAnyApplyToYou.bullet2"))</li>
+                <li>@Html(messages("pages.serviceCriteriaFailure.doAnyApplyToYou.bullet3"))</li>
+                <li>@Html(messages("pages.serviceCriteriaFailure.doAnyApplyToYou.bullet4"))</li>
+            </ul>
+
+            <p>@Html(messages("pages.serviceCriteriaFailure.doAnyApplyToYou.p1"))</p>
+
+        </div>
+
+        <div id="applying-for-any-of-text" class="@cssClass("applyingForAnyOf")">
+
+            <p>@Html(messages("pages.serviceCriteriaFailure.linkToLegacyApp2"))</p>
+
+            <ul class="list list-bullet">
+                <li>@Html(messages("pages.serviceCriteriaFailure.applyingForAnyOf.bullet1"))</li>
+                <li>@Html(messages("pages.serviceCriteriaFailure.applyingForAnyOf.bullet2"))</li>
+            </ul>
+
+            <p>@Html(messages("pages.serviceCriteriaFailure.applyingForAnyOf.p1"))</p>
+            <p>@Html(messages("pages.serviceCriteriaFailure.applyingForAnyOf.p2"))</p>
+
+        </div>
+
+        <div id="company-will-do-any-of-text" class="@cssClass("companyWillDoAnyOf")">
+
+            <p>@Html(messages("pages.serviceCriteriaFailure.companyWillDoAnyOf.p1"))</p>
+
+            <ul class="list list-bullet">
+                <li>@Html(messages("pages.serviceCriteriaFailure.companyWillDoAnyOf.bullet1"))</li>
+                <li>@Html(messages("pages.serviceCriteriaFailure.companyWillDoAnyOf.bullet2"))</li>
+                <li>@Html(messages("pages.serviceCriteriaFailure.companyWillDoAnyOf.bullet3"))</li>
+            </ul>
+
+            <p>@Html(messages("pages.serviceCriteriaFailure.linkToLegacyApp"))</p>
+
+        </div>
+
+
+        <p>&nbsp;</p>
+    }
+
+    @form(action = Call("GET", "https://online.hmrc.gov.uk/registration/newbusiness/business-allowed")) {
+        <div class="form-group">
+            <button type="submit" class="btn button" role="button" id="continue">
+            @messages("pages.serviceCriteriaFailure.button.linkToLegacyApp")
+            </button>
+        </div>
+    }
 }

--- a/app/views/pages/over_threshold.scala.html
+++ b/app/views/pages/over_threshold.scala.html
@@ -24,95 +24,88 @@
 
 @main_template(title = messages("pages.thresholdQuestion1.title"), scriptElem = Some(Html(s"""<script type="text/javascript" src='${routes.Assets.at("javascripts/main.js")}'></script>"""))) {
 
-  <div class="grid-row">
-    <div class="column-two-thirds">
+    @errorSummary(
+        Messages("app.common.errorSummaryLabel"),
+        overThresholdForm
+    )
 
-        @errorSummary(
-            Messages("app.common.errorSummaryLabel"),
-            overThresholdForm
-        )
-
-        <header class="page-header">
-            <h1 class="form-title heading-xlarge" id="pageHeading">
-            @messages("pages.thresholdQuestion1.heading", dateOfIncorporation)
-            </h1>
-        </header>
+    <header class="page-header">
+        <h1 class="form-title heading-xlarge" id="pageHeading">
+        @messages("pages.thresholdQuestion1.heading", dateOfIncorporation)
+        </h1>
+    </header>
 
 
-        <p>@messages("pages.thresholdQuestion1.p1")</p>
+    <p>@messages("pages.thresholdQuestion1.p1")</p>
 
-        @govHelpers.form(action = controllers.routes.OverThresholdController.submit()) {
-            <div class="form-group">
-                <fieldset class="inline">
-                @defining(DateTimeFormatter
-                        .ofLocalizedDate(java.time.format.FormatStyle.LONG)
-                        .withLocale(java.util.Locale.UK)) { formatter =>
+    @govHelpers.form(action = controllers.routes.OverThresholdController.submit()) {
+        <div class="form-group">
+            <fieldset class="inline">
+            @defining(DateTimeFormatter
+                    .ofLocalizedDate(java.time.format.FormatStyle.LONG)
+                    .withLocale(java.util.Locale.UK)) { formatter =>
 
-                        @vatInputRadioGroup(
-                            overThresholdForm("overThresholdRadio"),
-                            Seq(
-                                "true" -> Messages("app.common.yes"),
-                                "false" -> Messages("app.common.no")
-                            ),
-                            '_labelAfter -> true,
-                            '_labelClass -> "block-label",
-                            '_legend -> ""
-                        )
+                    @vatInputRadioGroup(
+                        overThresholdForm("overThresholdRadio"),
+                        Seq(
+                            "true" -> Messages("app.common.yes"),
+                            "false" -> Messages("app.common.no")
+                        ),
+                        '_labelAfter -> true,
+                        '_labelClass -> "block-label",
+                        '_legend -> ""
+                    )
+                }
+
+                <div class="panel panel-indent hidden" id="overThreshold_date_panel">
+                    <h2 class="heading-medium">@messages("pages.thresholdQuestion1.panel.heading")</h2>
+
+                    <span class="form-hint">@messages("pages.thresholdQuestion1.panel.hint")</span>
+
+                    @defining(overThresholdForm("overThreshold").errors.nonEmpty) { errorPresent =>
+                        <div class="form-date @if(errorPresent) { form-group-error }">
+
+                            <fieldset id="over-threshold">
+                                <legend></legend>
+                                <label><span class="hidden">Over Threshold input</span>
+                                @overThresholdForm.error("overThreshold").map { error =>
+                                    <span class="error-notification" role="tooltip">
+                                        @messages(error.message, error.args: _*)
+                                    </span>
+                                }
+                                    @*this is to make the clickable link in the error summary jump to the relevant place in the page*@
+                                    <input type="hidden" name="overThreshold" value="" id="overThreshold" class="hidden" />
+                                </label>
+
+                                @vatInput(
+                                    overThresholdForm("overThreshold.month"),
+                                    '_divClass -> "form-group",
+                                    '_inputClass -> "form-control",
+                                    '_maxlength -> 2,
+                                    '_label -> Messages("pages.thresholdQuestion1.month"),
+                                    '_labelClass -> "form-label"
+                                )
+
+                                @vatInput(
+                                    overThresholdForm("overThreshold.year"),
+                                    '_divClass -> "form-group form-group-year",
+                                    '_inputClass -> "form-control",
+                                    '_maxlength -> 4,
+                                    '_label -> Messages("pages.thresholdQuestion1.year"),
+                                    '_labelClass -> "form-label"
+                                )
+                            </fieldset>
+                        </div>
+
                     }
+                </div>
+            </fieldset>
+        </div>
 
-                    <div class="panel panel-indent hidden" id="overThreshold_date_panel">
-                        <h2 class="heading-medium">@messages("pages.thresholdQuestion1.panel.heading")</h2>
-
-                        <span class="form-hint">@messages("pages.thresholdQuestion1.panel.hint")</span>
-
-                        @defining(overThresholdForm("overThreshold").errors.nonEmpty) { errorPresent =>
-                            <div class="form-date @if(errorPresent) { form-group-error }">
-
-                                <fieldset id="over-threshold">
-                                    <legend></legend>
-                                    <label><span class="hidden">Over Threshold input</span>
-                                    @overThresholdForm.error("overThreshold").map { error =>
-                                        <span class="error-notification" role="tooltip">
-                                            @messages(error.message, error.args: _*)
-                                        </span>
-                                    }
-                                        @*this is to make the clickable link in the error summary jump to the relevant place in the page*@
-                                        <input type="hidden" name="overThreshold" value="" id="overThreshold" class="hidden" />
-                                    </label>
-
-                                    @vatInput(
-                                        overThresholdForm("overThreshold.month"),
-                                        '_divClass -> "form-group",
-                                        '_inputClass -> "form-control",
-                                        '_maxlength -> 2,
-                                        '_label -> Messages("pages.thresholdQuestion1.month"),
-                                        '_labelClass -> "form-label"
-                                    )
-
-                                    @vatInput(
-                                        overThresholdForm("overThreshold.year"),
-                                        '_divClass -> "form-group form-group-year",
-                                        '_inputClass -> "form-control",
-                                        '_maxlength -> 4,
-                                        '_label -> Messages("pages.thresholdQuestion1.year"),
-                                        '_labelClass -> "form-label"
-                                    )
-                                </fieldset>
-                            </div>
-
-                        }
-                    </div>
-                </fieldset>
-            </div>
-
-            <div class="form-group">
-                <button class="btn button" type="submit" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-            </div>
-        }
-
-    </div>
-  </div>
-
+        <div class="form-group">
+            <button class="btn button" type="submit" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+        </div>
+    }
 }
 
 <script type="text/javascript">

--- a/app/views/pages/taxable_turnover.scala.html
+++ b/app/views/pages/taxable_turnover.scala.html
@@ -22,39 +22,33 @@
 
 @main_template(title = messages("pages.taxable.turnover.title")) {
 
-  <div class="column-one-third">
+  @errorSummary(
+    Messages("app.common.errorSummaryLabel"),
+    taxableTurnoverForm
+  )
 
-      @errorSummary(
-        Messages("app.common.errorSummaryLabel"),
-        taxableTurnoverForm
-      )
+  <h1 class="form-title heading-large" id="pageHeading">@messages("pages.taxable.turnover.heading")</h1>
 
-      <h1 class="form-title heading-large" id="pageHeading">@messages("pages.taxable.turnover.heading")</h1>
+  <p>@messages("pages.taxable.turnover.p1")</p>
 
-      <p>@messages("pages.taxable.turnover.p1")</p>
+  @govHelpers.form(action = controllers.routes.TaxableTurnoverController.submit()) {
+  <div class="form-group">
+    <fieldset class="inline">
+        <span id="taxableTurnoverRadio"/>
+        @vatInputRadioGroup(
+            field = taxableTurnoverForm("taxableTurnoverRadio"),
+            Seq(
+              TaxableTurnover.TAXABLE_YES -> Messages("app.common.yes"),
+              TaxableTurnover.TAXABLE_NO -> Messages("app.common.no")
+            ),
+            '_labelAfter -> true,
+            '_labelClass -> "block-label"
+        )
+    </fieldset>
+  </div>
+  <div class="form-group">
+    <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+  </div>
 
-      @govHelpers.form(action = controllers.routes.TaxableTurnoverController.submit()) {
-      <div class="form-group">
-        <fieldset class="inline">
-            <span id="taxableTurnoverRadio"/>
-            @vatInputRadioGroup(
-                field = taxableTurnoverForm("taxableTurnoverRadio"),
-                Seq(
-                  TaxableTurnover.TAXABLE_YES -> Messages("app.common.yes"),
-                  TaxableTurnover.TAXABLE_NO -> Messages("app.common.no")
-                ),
-                '_labelAfter -> true,
-                '_labelClass -> "block-label"
-            )
-        </fieldset>
-       
-      </div>
-      <div class="form-group">
-        <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-      </div>
-
-      }
-
-    </div>
-
+  }
 }

--- a/app/views/pages/use_this_service.scala.html
+++ b/app/views/pages/use_this_service.scala.html
@@ -19,21 +19,15 @@
 
 @main_template(title = messages("pages.eligibility.start.title")) {
 
-<div class="grid-row">
-    <div class="column-one-third">
+    <header class="page-header">
+        <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.eligibility.start.heading")</h1>
+    </header>
 
-        <header class="page-header">
-            <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.eligibility.start.heading")</h1>
-        </header>
-
-        <p>@messages("pages.eligibility.start.para1")</p>
-        <br>
-        @form(action = controllers.routes.ServiceCriteriaQuestionsController.show("haveNino")) {
-            <div class="form-group">
-                <button class="button-get-started" role="button" id="save-and-continue">@messages("app.common.continue")</button>
-            </div>
-        }
-    </div>
-
-</div>
+    <p>@messages("pages.eligibility.start.para1")</p>
+    <br>
+    @form(action = controllers.routes.ServiceCriteriaQuestionsController.show("haveNino")) {
+        <div class="form-group">
+            <button class="button-get-started" role="button" id="save-and-continue">@messages("app.common.continue")</button>
+        </div>
+    }
 }

--- a/app/views/pages/voluntary_registration.scala.html
+++ b/app/views/pages/voluntary_registration.scala.html
@@ -22,40 +22,35 @@
 
 @main_template(title = messages("pages.voluntary.registration.title")) {
 
-    <div class="column-one-third">
+    @errorSummary(
+        Messages("app.common.errorSummaryLabel"),
+        voluntaryRegistrationForm
+    )
 
-        @errorSummary(
-            Messages("app.common.errorSummaryLabel"),
-            voluntaryRegistrationForm
-        )
+    <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.voluntary.registration.heading")</h1>
 
-        <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.voluntary.registration.heading")</h1>
+    <p>@messages("pages.voluntary.registration.para1")</p>
+    <p>@messages("pages.voluntary.registration.para2")</p>
 
-        <p>@messages("pages.voluntary.registration.para1")</p>
-        <p>@messages("pages.voluntary.registration.para2")</p>
+    @govHelpers.form(action = controllers.routes.VoluntaryRegistrationController.submit()) {
+        <div class="form-group">
+            <fieldset class="inline">
+                <span id="voluntaryRegistrationRadio"/>
+                @vatInputRadioGroup(
+                    field = voluntaryRegistrationForm("voluntaryRegistrationRadio"),
+                    Seq(
+                        VoluntaryRegistration.REGISTER_YES -> Messages("app.common.yes"),
+                        VoluntaryRegistration.REGISTER_NO -> Messages("app.common.no")
+                    ),
+                    '_labelAfter -> true,
+                    '_labelClass -> "block-label"
+                )
+            </fieldset>
+        </div>
 
-        @govHelpers.form(action = controllers.routes.VoluntaryRegistrationController.submit()) {
-            <div class="form-group">
-                <fieldset class="inline">
-                    <span id="voluntaryRegistrationRadio"/>
-                    @vatInputRadioGroup(
-                        field = voluntaryRegistrationForm("voluntaryRegistrationRadio"),
-                        Seq(
-                            VoluntaryRegistration.REGISTER_YES -> Messages("app.common.yes"),
-                            VoluntaryRegistration.REGISTER_NO -> Messages("app.common.no")
-                        ),
-                        '_labelAfter -> true,
-                        '_labelClass -> "block-label"
-                    )
-                </fieldset>
-            </div>
+        <div class="form-group">
+            <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+        </div>
 
-            <div class="form-group">
-                <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-            </div>
-
-        }
-
-    </div>
-
+    }
 }

--- a/app/views/pages/voluntary_registration_reason.scala.html
+++ b/app/views/pages/voluntary_registration_reason.scala.html
@@ -22,46 +22,41 @@
 
 @main_template(title = messages("pages.voluntary.registration.reason.title")) {
 
-  <div class="column-two-thirds">
-
-      @errorSummary(
-        Messages("app.common.errorSummaryLabel"),
-        voluntaryRegistrationForm
-      )
+  @errorSummary(
+    Messages("app.common.errorSummaryLabel"),
+    voluntaryRegistrationForm
+  )
 
 
-      <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.voluntary.registration.reason.heading")</h1>
+  <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.voluntary.registration.reason.heading")</h1>
 
-      @govHelpers.form(action = controllers.routes.VoluntaryRegistrationReasonController.submit()) {
-      <div class="form-group">
-        <fieldset class="inline">
-            <span id="voluntaryRegistrationReasonRadio"/>
-            @vatInputRadioGroup(
-                field = voluntaryRegistrationForm("voluntaryRegistrationReasonRadio"),
-                Seq(
-                  VoluntaryRegistrationReason.SELLS -> Messages("pages.voluntary.registration.reason.radio.sells"),
-                  VoluntaryRegistrationReason.INTENDS_TO_SELL -> Messages("pages.voluntary.registration.reason.radio.intendsToSell"),
-                  VoluntaryRegistrationReason.NEITHER -> Messages("pages.voluntary.registration.reason.radio.neither")
-                ),
-                '_labelAfter -> true,
-                '_labelClass -> "block-label"
-            )
-        </fieldset>
+  @govHelpers.form(action = controllers.routes.VoluntaryRegistrationReasonController.submit()) {
+  <div class="form-group">
+    <fieldset class="inline">
+        <span id="voluntaryRegistrationReasonRadio"/>
+        @vatInputRadioGroup(
+            field = voluntaryRegistrationForm("voluntaryRegistrationReasonRadio"),
+            Seq(
+              VoluntaryRegistrationReason.SELLS -> Messages("pages.voluntary.registration.reason.radio.sells"),
+              VoluntaryRegistrationReason.INTENDS_TO_SELL -> Messages("pages.voluntary.registration.reason.radio.intendsToSell"),
+              VoluntaryRegistrationReason.NEITHER -> Messages("pages.voluntary.registration.reason.radio.neither")
+            ),
+            '_labelAfter -> true,
+            '_labelClass -> "block-label"
+        )
+    </fieldset>
 
-        <div class="panel panel-indent panel-border-narrow hidden" id="neither_panel">
-            <p>@messages("pages.voluntary.registration.reason.panels.neither.para")</p>
-        </div>
-
-      </div>
-
-      <div class="form-group">
-        <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-      </div>
-
-      }
-
+    <div class="panel panel-indent panel-border-narrow hidden" id="neither_panel">
+        <p>@messages("pages.voluntary.registration.reason.panels.neither.para")</p>
     </div>
 
+  </div>
+
+  <div class="form-group">
+    <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+  </div>
+
+  }
 }
 
 <script type="text/javascript">


### PR DESCRIPTION
Every page has 1 of the following arrangements of parent wrapper
around the cointent that sits within .content__body wrapper we get
from the HMRC template:
- .grid-row > .column-one-third
- .grid-row > .column-two-thirds
- .column-two-thirds
- .column-one-third

The majority of the time none of these classes are doing anything.
So at best we have 1 or 2 extar content div wrapper that are
redundant. But every now and then they are actually picking up the
styles for the classes assigned to the divs. Meaning that the
content displays as either 1/3 or 2/3 of the the parent
.content__body which is already set to 61.6666667% width, which
breaks the layout.

### Before (when classes pick up styles)
![screen shot 2017-10-12 at 13 51 49](https://user-images.githubusercontent.com/1692222/31496764-988a5860-af54-11e7-8662-39c9ab4f562c.png)

### After
![screen shot 2017-10-12 at 13 52 06](https://user-images.githubusercontent.com/1692222/31496775-a3184ada-af54-11e7-931d-8dccb41fea79.png)

