### PR TITLE
Removed .inline class to fix radio button spacing

### DIFF
--- a/app/views/pages/voluntary_registration_reason.scala.html
+++ b/app/views/pages/voluntary_registration_reason.scala.html
@@ -32,7 +32,7 @@
 
   @govHelpers.form(action = controllers.routes.VoluntaryRegistrationReasonController.submit()) {
   <div class="form-group">
-    <fieldset class="inline">
+    <fieldset>
         <span id="voluntaryRegistrationReasonRadio"/>
         @vatInputRadioGroup(
             field = voluntaryRegistrationForm("voluntaryRegistrationReasonRadio"),


### PR DESCRIPTION
Fixed broken radio button spacing by removing .inline class, which is meant to use with Yes/No radio buttons that sit side by side.

## Before
![screen shot 2017-10-13 at 14 35 16](https://user-images.githubusercontent.com/1692222/31548767-f0573ae8-b023-11e7-8a3d-f4d58c8e6c16.png)

## After
![screen shot 2017-10-13 at 14 34 53](https://user-images.githubusercontent.com/1692222/31548775-f95b0d36-b023-11e7-8b42-1bce80f29be1.png)
