### PR TITLE
Update check your answers page inline with GDS recommendations

### DIFF
--- a/app/views/helpers/templates/summaryRow.scala.html
+++ b/app/views/helpers/templates/summaryRow.scala.html
@@ -22,17 +22,16 @@
    @messages(ans) <br>
 }
 
-<tr id="@{row.id}">
-    <td id="@{row.id}Question" class="question"><span style="font-weight:bold">@messages(s"pages.summary.${row.id}", questionArg)</span></td>
-    <td id="@{row.id}Answer" class="answer">
-        @for(answer <- row.answerMessageKeys) {
-            @displayAnswer(answer)
-        }
-    </td>
-    <td class="change-answer">
-        @row.changeLink.map { linkLocation =>
-            <a href="@linkLocation" id="@{row.id}ChangeLink">@messages("app.common.change") &nbsp;
-        <span class="visually-hidden"> @messages(s"pages.summary.${row.id}", questionArg)</span></a>
-        }
-    </td>
-</tr>
+<div id="@{row.id}">
+  <dt class="cya-question" id="@{row.id}Question">@messages(s"pages.summary.${row.id}", questionArg)</dt>
+  <dd class="cya-answer" id="@{row.id}Answer">
+    @for(answer <- row.answerMessageKeys) {
+        @displayAnswer(answer)
+    }
+  </dd>
+  <dd class="cya-change">
+    @row.changeLink.map { linkLocation =>
+        <a href="@linkLocation" id="@{row.id}ChangeLink">@messages("app.common.change")<span class="visuallyhidden">&nbsp; @messages(s"pages.summary.${row.id}", questionArg)</span></a>
+    }
+  </dd>
+</div>

--- a/app/views/pages/summary_eligibility.scala.html
+++ b/app/views/pages/summary_eligibility.scala.html
@@ -20,26 +20,26 @@
 @(summaryModel: Summary, questionArg: String = "")(implicit request: Request[_], messages: Messages)
 @main_template(title = messages("pages.summary.title")) {
 
-    <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.summary.heading")</h1>
+  <h1 class="form-title heading-large" id="pageHeading">@messages("pages.summary.heading")</h1>
 
-        @for(section <- summaryModel.sections) {
-            @if(section.display) {
-                <section>
-                    <h2 class="heading-medium">@Messages(s"pages.summary.${section.id}.sectionHeading")</h2>
-                    <table class="check-your-answers form-group">
-                        @for((row, doDisplayRow) <- section.rows) {
-                            @if(doDisplayRow) {
-                                 @summaryRow(row, questionArg)
-                            }
-                        }
-                    </table>
-                </section>
+    @for(section <- summaryModel.sections) {
+      @if(section.display) {
+        <section>
+          <h2 class="heading-medium">@Messages(s"pages.summary.${section.id}.sectionHeading")</h2>
+          <dl class="govuk-check-your-answers cya-questions-long">
+            @for((row, doDisplayRow) <- section.rows) {
+              @if(doDisplayRow) {
+                   @summaryRow(row, questionArg)
+              }
             }
-        }
+          </dl>
+        </section>
+      }
+    }
 
-        @form(action = controllers.routes.EligibilitySummaryController.submit()) {
-            <div class="form-group">
-                <button class="button-get-started" role="button" id="save-and-continue">@messages("app.common.continue")</button>
-            </div>
-        }
+    @form(action = controllers.routes.EligibilitySummaryController.submit()) {
+      <div class="form-group">
+        <button class="button-get-started" role="button" id="save-and-continue">@messages("app.common.continue")</button>
+      </div>
+    }
 }

--- a/app/views/pages/threshold_summary.scala.html
+++ b/app/views/pages/threshold_summary.scala.html
@@ -21,27 +21,20 @@
 
 @main_template(title = messages("pages.thresholdSummary.title")) {
 
-    <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.thresholdSummary.heading")</h1>
+    <h1 class="form-title heading-large" id="pageHeading">@messages("pages.thresholdSummary.heading")</h1>
 
     @for(section <- summaryModel.sections) {
         @if(section.display) {
 
             <section>
-                <table class="check-your-answers form-group">
-                    @*To show grey line at top of section*@
-                    <tr>
-                        <th style="white-space: normal;
-                            width: 50%;" class="question"></th>
-                        <td class="answer"></td>
-                        <td class="change"><span class="visuallyhidden"></span></td>
-                    </tr>
+                <dl class="govuk-check-your-answers cya-questions-long">
                     @*Iterates to display sections and rows*@
                     @for((row, doDisplayRow) <- section.rows) {
                         @if(doDisplayRow) {
                             @summaryRow(row, dateOfIncorporation)
                         }
                     }
-                </table>
+                </dl>
             </section>
         }
     }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -148,7 +148,7 @@ google-analytics {
 }
 
 assets {
-  version = "2.248.1"
+  version = "2.253.0"
   version = ${?ASSETS_FRONTEND_VERSION}
   url = "http://localhost:9032/assets/"
 }


### PR DESCRIPTION
This PR updates the check your answers page to use dl's moving away
from tables.

Changes made:
- update to dl from table
- reduce heading size using .heading-large

Note: visually this hasn't changed much

### Before
![vat-fe-elig-before](https://user-images.githubusercontent.com/1692222/33325351-e5d29244-d449-11e7-819a-e1a0856f19a3.jpg)

### After
![vat-fe-elig-after](https://user-images.githubusercontent.com/1692222/33325367-f050e630-d449-11e7-8e78-60a87f624cfe.jpg)

Changes made to threshold summary page too.
- Reduced heading size
- Removed empty row that's only there to provide the bottom border
- Updated to use dl, as above

### Before
<img width="1092" alt="threshold-before" src="https://user-images.githubusercontent.com/1692222/33377739-6e6131ae-d50a-11e7-9666-d3ae364778d3.png">

### After
<img width="1117" alt="threshold-after" src="https://user-images.githubusercontent.com/1692222/33377748-774e97de-d50a-11e7-99df-fa08d098e152.png">

