### PR TITLE
Uplift HMRC AF to v3 and uplift styles

### DIFF
--- a/app/views/helpers/mainContentHeader.scala.html
+++ b/app/views/helpers/mainContentHeader.scala.html
@@ -18,9 +18,7 @@
 
 @backButton = {
     @if(backButtonEnabled) {
-        <div style="width:40%; display: inline-block" align="left" class="form-group-compound">
-            <a id="back" class="back-link" href="javascript:history.back()">@messages("app.common.back")</a>
-        </div>
+        <a id="back" class="link-back" href="javascript:history.back()">@messages("app.common.back")</a>
     }
 }
 

--- a/app/views/pages/summary_eligibility.scala.html
+++ b/app/views/pages/summary_eligibility.scala.html
@@ -24,7 +24,7 @@
 
     @for(section <- summaryModel.sections) {
       @if(section.display) {
-        <section>
+        <section class="form-group">
           <h2 class="heading-medium">@Messages(s"pages.summary.${section.id}.sectionHeading")</h2>
           <dl class="govuk-check-your-answers cya-questions-long">
             @for((row, doDisplayRow) <- section.rows) {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -165,7 +165,7 @@ google-analytics {
 }
 
 assets {
-  version = "2.253.0"
+  version = "3.0.2"
   version = ${?ASSETS_FRONTEND_VERSION}
   url = "http://localhost:9032/assets/"
 }

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -1,4 +1,5 @@
 @import 'form-validation.css';
+@import 'taas.css';
 /* position labels above input fields in cascading forms */
 label.cascading span {
 	display: block;

--- a/public/stylesheets/taas.css
+++ b/public/stylesheets/taas.css
@@ -1,0 +1,28 @@
+/*
+	Remove inherited float style form HMRC from .content__body which breaks layout of back button
+	https://github.com/hmrc/assets-frontend/blob/3610585baeb96bb4ad9d73d20cfb73864e095b50/assets/scss/layouts/_page.scss#L59
+
+	There are plans to update and remove .content__body styles, but until then we need this fix in place.
+*/
+
+@media (min-width: 641px) {
+	.content__body {
+	    float: none;
+	}
+}
+
+/* ---- Get help with this page link over rides ---- */
+
+.report-error .report-error__toggle {
+	font-size: 16px;
+}
+
+@media (min-width: 641px) {
+	.report-error .report-error__toggle {
+		font-size: 19px;
+	}
+}
+
+.report-error {
+	margin-top: 0;
+}

--- a/test/builders/AuthBuilder.scala
+++ b/test/builders/AuthBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/builders/SessionBuilder.scala
+++ b/test/builders/SessionBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/common/EnumSpec.scala
+++ b/test/common/EnumSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/config/WhitelistFilterSpec.scala
+++ b/test/config/WhitelistFilterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/connectors/BusinessRegistrationConnectorSpec.scala
+++ b/test/connectors/BusinessRegistrationConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/connectors/CompanyRegistrationConnectorSpec.scala
+++ b/test/connectors/CompanyRegistrationConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/connectors/IncorporationInformationConnectorSpec.scala
+++ b/test/connectors/IncorporationInformationConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/connectors/KeystoreConnectorSpec.scala
+++ b/test/connectors/KeystoreConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/connectors/S4LConnectorSpec.scala
+++ b/test/connectors/S4LConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/connectors/VatRegistrationConnectorSpec.scala
+++ b/test/connectors/VatRegistrationConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/controllers/EligibilityControllerSpec.scala
+++ b/test/controllers/EligibilityControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/controllers/EligibilitySummaryControllerSpec.scala
+++ b/test/controllers/EligibilitySummaryControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/controllers/SessionControllerSpec.scala
+++ b/test/controllers/SessionControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/controllers/TaxableTurnoverControllerSpec.scala
+++ b/test/controllers/TaxableTurnoverControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/controllers/ThresholdControllerSpec.scala
+++ b/test/controllers/ThresholdControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/controllers/ThresholdSummaryControllerSpec.scala
+++ b/test/controllers/ThresholdSummaryControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/controllers/VatRegistrationControllerSpec.scala
+++ b/test/controllers/VatRegistrationControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/controllers/VoluntaryRegistrationControllerSpec.scala
+++ b/test/controllers/VoluntaryRegistrationControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/controllers/VoluntaryRegistrationReasonControllerSpec.scala
+++ b/test/controllers/VoluntaryRegistrationReasonControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/controllers/builders/SummarySectionBuilderSpec.scala
+++ b/test/controllers/builders/SummarySectionBuilderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/controllers/builders/SummaryVatThresholdBuilderSpec.scala
+++ b/test/controllers/builders/SummaryVatThresholdBuilderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/fixtures/LoginFixture.scala
+++ b/test/fixtures/LoginFixture.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/fixtures/VatRegistrationFixture.scala
+++ b/test/fixtures/VatRegistrationFixture.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/forms/ExpectationThresholdFormSpec.scala
+++ b/test/forms/ExpectationThresholdFormSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/forms/FormValidationSpec.scala
+++ b/test/forms/FormValidationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/forms/OverThresholdFormFactorySpec.scala
+++ b/test/forms/OverThresholdFormFactorySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/forms/ServiceCriteriaFormFactorySpec.scala
+++ b/test/forms/ServiceCriteriaFormFactorySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/forms/TaxableTurnoverFormSpec.scala
+++ b/test/forms/TaxableTurnoverFormSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/forms/VoluntaryRegistrationFormSpec.scala
+++ b/test/forms/VoluntaryRegistrationFormSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/forms/VoluntaryRegistrationReasonFormSpec.scala
+++ b/test/forms/VoluntaryRegistrationReasonFormSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/helpers/FormInspectors.scala
+++ b/test/helpers/FormInspectors.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/helpers/FutureAssertions.scala
+++ b/test/helpers/FutureAssertions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/helpers/VatRegSpec.scala
+++ b/test/helpers/VatRegSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/mocks/EligibilityServiceMock.scala
+++ b/test/mocks/EligibilityServiceMock.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/mocks/KeystoreMock.scala
+++ b/test/mocks/KeystoreMock.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/mocks/SaveForLaterMock.scala
+++ b/test/mocks/SaveForLaterMock.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/mocks/ThresholdServiceMock.scala
+++ b/test/mocks/ThresholdServiceMock.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/mocks/VatMocks.scala
+++ b/test/mocks/VatMocks.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/mocks/VatRegConnectorMock.scala
+++ b/test/mocks/VatRegConnectorMock.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/mocks/WSHTTPMock.scala
+++ b/test/mocks/WSHTTPMock.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/models/views/ExpectationOverThresholdViewSpec.scala
+++ b/test/models/views/ExpectationOverThresholdViewSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/models/views/OverThresholdViewSpec.scala
+++ b/test/models/views/OverThresholdViewSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/models/views/VoluntaryRegistrationReasonSpec.scala
+++ b/test/models/views/VoluntaryRegistrationReasonSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/services/CancellationServiceSpec.scala
+++ b/test/services/CancellationServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/services/CurrentProfileServiceSpec.scala
+++ b/test/services/CurrentProfileServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/services/EligibilityServiceSpec.scala
+++ b/test/services/EligibilityServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/services/SummaryServiceSpec.scala
+++ b/test/services/SummaryServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/services/ThresholdServiceSpec.scala
+++ b/test/services/ThresholdServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/services/VatRegistrationServiceSpec.scala
+++ b/test/services/VatRegistrationServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/transformers/ToEligibilityViewSpec.scala
+++ b/test/transformers/ToEligibilityViewSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/transformers/ToThresholdViewSpec.scala
+++ b/test/transformers/ToThresholdViewSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/utils/FeatureSwitchSpec.scala
+++ b/test/utils/FeatureSwitchSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/utils/SessionProfileSpec.scala
+++ b/test/utils/SessionProfileSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/views/pages/ExpectedOverThresholdPageSpec.scala
+++ b/test/views/pages/ExpectedOverThresholdPageSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/views/pages/OverThresholdPageSpec.scala
+++ b/test/views/pages/OverThresholdPageSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/views/pages/ThresholdSummaryPageSpec.scala
+++ b/test/views/pages/ThresholdSummaryPageSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
A move to uplift to AF v3, which is a slow move towards eventually
moving away from AF all together.

As part of the work running through the app to see how AF v3 affects
the service layout I updated and fixed a couple of features like the
back button, spacing and font sizing around the continue button and
spacing on summary page continue button.

### Before
<img width="1440" alt="screen shot 2018-01-15 at 10 12 08" src="https://user-images.githubusercontent.com/1692222/34938306-cb5ff620-f9df-11e7-9a91-9f16f387f225.png">

### After
<img width="1440" alt="screen shot 2018-01-15 at 10 37 46" src="https://user-images.githubusercontent.com/1692222/34938485-6d544936-f9e0-11e7-8c2c-d2eb39ae1022.png">

