### PR TITLE
Standardising panel border widths

### DIFF
--- a/app/views/pages/applying_for_vat_exemption.scala.html
+++ b/app/views/pages/applying_for_vat_exemption.scala.html
@@ -45,7 +45,7 @@
     <div class="form-group">
         <details role="group">
             <summary role="button" aria-controls="details-content-1" aria-expanded="false"><span class="summary">@messages("pages.eligibility.applyingForVatExemption.panel.title")</span></summary>
-            <div class="panel panel-indent" id="details-content-1" aria-hidden="true">
+            <div class="panel panel-border-narrow" id="details-content-1" aria-hidden="true">
                 <p>@messages("pages.eligibility.applyingForVatExemption.panel.p1")</p>
                 <p>@messages("pages.eligibility.applyingForVatExemption.panel.p2")</p>
                 <ul class="list list-bullet">


### PR DESCRIPTION
As part of a tidy up story SCRS-10408, I have updated all panel classes sot that they are up to date and consistent.

## Before
<img width="612" alt="screen shot 2018-02-06 at 10 29 11" src="https://user-images.githubusercontent.com/1692222/35854720-01612e06-0b29-11e8-97a1-ae64a586e1f6.png">

## After
<img width="636" alt="screen shot 2018-02-06 at 10 28 24" src="https://user-images.githubusercontent.com/1692222/35854735-090d5d50-0b29-11e8-8968-d4cd772bc4cb.png">

