### PR TITLE
Updating button classes to remove unnecessary 'start' arrow

### DIFF
--- a/app/views/pages/summary_eligibility.scala.html
+++ b/app/views/pages/summary_eligibility.scala.html
@@ -39,7 +39,7 @@
 
     @form(action = controllers.routes.EligibilitySummaryController.submit()) {
       <div class="form-group">
-        <button class="button-get-started" role="button" id="save-and-continue">@messages("app.common.continue")</button>
+        <button class="button" role="button" id="save-and-continue">@messages("app.common.continue")</button>
       </div>
     }
 }


### PR DESCRIPTION
Linked to https://github.com/hmrc/vat-registration-frontend/pull/373

Before and after screen shots below

![button-before-after](https://user-images.githubusercontent.com/1692222/37154678-a65a3404-22d8-11e8-9efe-72a321a5f8e1.jpg)
