### PR TITLE
Improve print styles for summary page

### DIFF
--- a/app/views/govuk_wrapper.scala.html
+++ b/app/views/govuk_wrapper.scala.html
@@ -39,6 +39,7 @@
     <meta name="format-detection" content="telephone=no" />
     <link rel="stylesheet" href="@routes.Assets.at("stylesheets/main.css")">
     <link rel="stylesheet" href="@routes.Assets.at("stylesheets/timeout-dialog.css")">
+    <link rel="stylesheet" media="print" type="text/css" href="@routes.Assets.at("stylesheets/vat-print.css")">
 }
 
 @headerNavLinks = {

--- a/public/stylesheets/vat-print.css
+++ b/public/stylesheets/vat-print.css
@@ -1,0 +1,57 @@
+/* Print styles to improve Summary / Check your answers pages */
+
+/* removes padding so the content aligns with the header in print */
+article h1+h2 {
+	margin-bottom: 30px;
+}
+
+.heading-medium {
+	margin: 10px 0 10px;
+}
+
+
+/* Styles for layout using dl */
+
+.govuk-check-your-answers {
+	margin: 0 0 40px; 
+}
+
+.cya-question,
+.cya-answer {
+	display: inline-block;
+	width: 50%;
+	vertical-align: top !important;
+}
+
+.cya-answer {
+	width: 33.33%;
+	padding: 10px 0;
+	margin-bottom: 0;
+}
+
+
+/* template styles */
+#global-header {
+	margin-bottom: 0;
+}
+
+.centered-content,
+#content {
+	margin: 0;
+	padding: 0;
+}
+
+.cya-change,
+.report-error,
+.button,
+.link-back,
+.phase-banner,
+.header__menu__proposition-links,
+.menu {
+	display: none;
+}
+
+.header__menu__proposition-name {
+	color: #000;
+	font-size: 27px;
+}


### PR DESCRIPTION
This work has been done for CT, at some point when I have collaborated with HMRC this will live in HMRC AF, so we can remove the local styles.

## Before
[VREFE-CYA-before.pdf](https://github.com/hmrc/vat-registration-eligibility-frontend/files/1830209/VREFE-CYA-before.pdf)

## After
[VREFE-CYA-after.pdf](https://github.com/hmrc/vat-registration-eligibility-frontend/files/1830211/VREFE-CYA-after.pdf)
