### PR TITLE
SCRS-11822 - changed config value for mongo ttl for 30 days in seconds, added in code to run on instantiation of Reactive mongo class to drop existing index for ttl and add new one in, also fixed IT tests not running

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -186,7 +186,7 @@ assets {
 
 mongodb {
   uri = "mongodb://localhost:27017/"${appName}
-  timeToLiveInSeconds = 3600
+  timeToLiveInSeconds = 2592000
 }
 
 urls {

--- a/it/repositories/SessionRepositoryISpec.scala
+++ b/it/repositories/SessionRepositoryISpec.scala
@@ -1,0 +1,41 @@
+package repositories
+
+import helpers.IntegrationSpecBase
+import play.api.Configuration
+import play.api.libs.json.Json
+import uk.gov.hmrc.http.cache.client.CacheMap
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+
+class SessionRepositoryISpec extends IntegrationSpecBase {
+
+  class Setup {
+    val newMongoInstance = new ReactiveMongoRepository(app.injector.instanceOf[Configuration], mongo)
+  }
+
+  "dropCollectionIndexTemp" should {
+    "drop collection , create index, drop index using dropCollectionIndexTemp then attempt to create index again Successfully" in new Setup {
+      await(newMongoInstance.drop)
+      await(newMongoInstance.collection.indexesManager.list()).isEmpty mustBe true
+      await(newMongoInstance.createIndex(newMongoInstance.fieldName, newMongoInstance.createdIndexName,10))
+      await(newMongoInstance.collection.indexesManager.list()).nonEmpty mustBe true
+      await(newMongoInstance.dropCollectionIndexTemp) mustBe true
+      await(newMongoInstance.collection.indexesManager.list()).nonEmpty mustBe true
+      await(newMongoInstance.collection.indexesManager.list()).map(_.name.getOrElse("")).contains("userAnswersExpiry") mustBe false
+      await(newMongoInstance.createIndex(newMongoInstance.fieldName, newMongoInstance.createdIndexName,129)) mustBe true
+      await(newMongoInstance.collection.indexesManager.list()).map(_.name.getOrElse("")).contains("userAnswersExpiry") mustBe true
+    }
+    "drop and create works sucessfully when documents are in the collection" in new Setup {
+      await(newMongoInstance.collection.indexesManager.list()).nonEmpty mustBe true
+      val record1 = CacheMap("1",Map("foo" -> Json.obj("" -> "")))
+      val record2 = CacheMap("2",Map("foo" -> Json.obj("" -> "")))
+      await(newMongoInstance.upsert(record1)) mustBe true
+      await(newMongoInstance.upsert(record2)) mustBe true
+      await(newMongoInstance.dropCollectionIndexTemp) mustBe true
+      await(newMongoInstance.collection.indexesManager.list()).map(_.name.getOrElse("")).contains("userAnswersExpiry") mustBe false
+      await(newMongoInstance.createIndex(newMongoInstance.fieldName, newMongoInstance.createdIndexName,129)) mustBe true
+      await(newMongoInstance.collection.indexesManager.list()).map(_.name.getOrElse("")).contains("userAnswersExpiry") mustBe true
+    }
+  }
+}

--- a/it/repositories/SessionRepositoryISpec.scala
+++ b/it/repositories/SessionRepositoryISpec.scala
@@ -32,10 +32,12 @@ class SessionRepositoryISpec extends IntegrationSpecBase {
       val record2 = CacheMap("2",Map("foo" -> Json.obj("" -> "")))
       await(newMongoInstance.upsert(record1)) mustBe true
       await(newMongoInstance.upsert(record2)) mustBe true
+      await(newMongoInstance.count) mustBe 2
       await(newMongoInstance.dropCollectionIndexTemp) mustBe true
       await(newMongoInstance.collection.indexesManager.list()).map(_.name.getOrElse("")).contains("userAnswersExpiry") mustBe false
       await(newMongoInstance.createIndex(newMongoInstance.fieldName, newMongoInstance.createdIndexName,129)) mustBe true
       await(newMongoInstance.collection.indexesManager.list()).map(_.name.getOrElse("")).contains("userAnswersExpiry") mustBe true
+      await(newMongoInstance.count) mustBe 2
     }
   }
 }

--- a/project/FrontendBuild.scala
+++ b/project/FrontendBuild.scala
@@ -24,7 +24,7 @@ private object AppDependencies {
   private val playReactivemongoVersion = "6.2.0"
   private val playConditionalFormMappingVersion = "0.2.0"
   private val playLanguageVersion = "3.4.0"
-  private val bootstrapVersion = "3.4.0"
+  private val bootstrapVersion = "3.6.0"
   private val scalacheckVersion = "1.13.4"
   private val jsoupVersion = "1.11.2"
   private val scoverageVersion = "1.3.1"

--- a/project/MicroService.scala
+++ b/project/MicroService.scala
@@ -43,6 +43,7 @@ trait MicroService {
     .settings(scalaSettings: _*)
     .settings(publishingSettings: _*)
     .settings(defaultSettings(): _*)
+    .settings(integrationTestSettings())
     .settings(
       scalacOptions ++= Seq("-feature"), //TODO: "-Xfatal-warnings" cause deprecated warnings to fail, what alternatives are there?
       libraryDependencies ++= appDependencies,
@@ -50,7 +51,6 @@ trait MicroService {
       evictionWarningOptions in update := EvictionWarningOptions.default.withWarnScalaVersionEviction(false)
     )
     .configs(IntegrationTest)
-    .settings(inConfig(IntegrationTest)(Defaults.itSettings): _*)
       .settings(resolvers ++= Seq(
         Resolver.bintrayRepo("hmrc", "releases"),
         Resolver.jcenterRepo,


### PR DESCRIPTION
SCRS-11822 - changed config value for mongo ttl for 30 days in seconds, added in code to run on instantiation of Reactive mongo class to drop existing index for ttl and add new one in, also fixed IT tests not running + dep uplift
## Checklist

* [x] I've included appropriate tests with any code I've added
* [x] I've executed the acceptance test pack locally to ensure there are no regressions
* [x] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [x] I've run a dependency check to ensure all dependencies are up to date 
