### PR TITLE
SAR-10072 | Upgrade hmrc-mongo-play-28 to latest version

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -8,7 +8,7 @@ private object AppDependencies {
   private val scalaTestPlusPlayVersion = "5.1.0"
   private val mockitoVersion = "3.3.3"
   private val httpCachingClientVersion = "9.6.0-play-28"
-  private val mongoPlayVersion = "0.64.0"
+  private val mongoPlayVersion = "0.68.0"
   private val playConditionalFormMappingVersion = "1.11.0-play-28"
   private val bootstrapVersion = "5.20.0"
   private val jsoupVersion = "1.13.1"


### PR DESCRIPTION
[SAR-10072](https://jira.tools.tax.service.gov.uk/browse/SAR-10072)

Upgrade hmrc-mongo-play library to latest version (0.68.0)

## Checklist

* [ ] I've included appropriate tests with any code I've added
* [X] I've executed the acceptance test pack locally to ensure there are no regressions
* [X] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [ ] I've run a dependency check to ensure all dependencies are up to date 
