### PR TITLE
SAR-10530 | Add missing legend to fieldset in date of business transfer page

### DIFF
--- a/app/views/DateOfBusinessTransfer.scala.html
+++ b/app/views/DateOfBusinessTransfer.scala.html
@@ -41,9 +41,9 @@
     @formWithCsrf(action = routes.DateOfBusinessTransferController.onSubmit()) {
         @inputDate(
             form = form,
-            legendContent = "",
+            legendContent = s"dateOfBusinessTransfer.heading.$togcColeKey",
             hintText = Some(s"dateOfBusinessTransfer.dateHint"),
-            legendClasses = "govuk-fieldset__legend--m",
+            legendClasses = "govuk-fieldset__legend--m govuk-visually-hidden",
             id = "relevantDate",
             legendAsPageHeading = false
         )

--- a/app/views/ThresholdTaxableSupplies.scala.html
+++ b/app/views/ThresholdTaxableSupplies.scala.html
@@ -44,9 +44,9 @@
     @formWithCsrf(action = routes.ThresholdTaxableSuppliesController.onSubmit()) {
         @inputDate(
             form = form,
-            legendContent = "",
+            legendContent = "thresholdTaxableSupplies.heading",
             hintText = Some("thresholdTaxableSupplies.dateHint"),
-            legendClasses = "govuk-fieldset__legend--m",
+            legendClasses = "govuk-fieldset__legend--m govuk-visually-hidden",
             id = "thresholdTaxableSuppliesDate",
             legendAsPageHeading = false
         )

--- a/test/views/DateOfBusinessTransferViewSpec.scala
+++ b/test/views/DateOfBusinessTransferViewSpec.scala
@@ -68,6 +68,10 @@ class DateOfBusinessTransferViewSpec extends ViewSpecBase {
         doc.select(Selectors.h1).text() mustBe h1Togc
       }
 
+      "have the correct legend" in {
+        doc.select(Selectors.legend(1)).text() mustBe h1Togc
+      }
+
       "have the correct paragraph" in {
         doc.select(Selectors.p(1)).text() mustBe paraTogc
       }
@@ -98,6 +102,10 @@ class DateOfBusinessTransferViewSpec extends ViewSpecBase {
 
       "have the correct heading" in {
         doc.select(Selectors.h1).text() mustBe h1Cole
+      }
+
+      "have the correct legend" in {
+        doc.select(Selectors.legend(1)).text() mustBe h1Cole
       }
 
       "have the correct paragraph" in {

--- a/test/views/ThresholdTaxableSuppliesViewSpec.scala
+++ b/test/views/ThresholdTaxableSuppliesViewSpec.scala
@@ -61,6 +61,10 @@ class ThresholdTaxableSuppliesViewSpec extends ViewSpecBase {
       doc.select(Selectors.h1).text() mustBe h1
     }
 
+    "have the correct legend" in {
+      doc.select(Selectors.legend(1)).text() mustBe h1
+    }
+
     "have the correct text" in {
       doc.select(Selectors.p(1)).text() mustBe testText
     }


### PR DESCRIPTION
[SAR-10530](https://jira.tools.tax.service.gov.uk/browse/SAR-10530)

** Bug fix**

As identified in accessibility report, add the missing legend to fieldset on date of business transfer page.

## Checklist

* [X] I've included appropriate tests with any code I've added
* [X] I've executed the acceptance test pack locally to ensure there are no regressions
* [X] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [ ] I've run a dependency check to ensure all dependencies are up to date 
